### PR TITLE
BUG: `CBAR.nodes` parameter was returning `None`

### DIFF
--- a/pyNastran/bdf/cards/elements/bars.py
+++ b/pyNastran/bdf/cards/elements/bars.py
@@ -413,6 +413,14 @@ class CBAR(LineElement):
     def node_ids(self):
         return [self.Ga(), self.Gb()]
 
+    @property
+    def nodes(self):
+        return [self.ga, self.gb]
+
+    @nodes.setter
+    def nodes(self, values):
+        return values
+
     @node_ids.setter
     def node_ids(self, value):
         raise ValueError("You cannot set node IDs like this...modify the node objects")


### PR DESCRIPTION
The `CBAR.nodes` attribute was always `None`, even after reading the bdf with `bdf.read_bdf(filename)`.

Some impacts on this issue:
- methods `CBAR.nodePositions`, `CBAR.get_node_positions` etc wouldn't work