### PR TITLE
ENH: get_edges for LineElements and RodElement

### DIFF
--- a/pyNastran/bdf/cards/elements/bars.py
+++ b/pyNastran/bdf/cards/elements/bars.py
@@ -136,6 +136,12 @@ class LineElement(Element):  # CBAR, CBEAM, CBEAM3, CBEND
         L = norm(self.nodes[1].Position() - self.nodes[0].Position())
         return L
 
+    def get_edges(self):
+        """
+        Return the edges
+        """
+        return [(self.nodes[0], self.nodes[1])]
+
 
 class CBAROR(object):
     type = 'CBAROR'

--- a/pyNastran/bdf/cards/elements/rods.py
+++ b/pyNastran/bdf/cards/elements/rods.py
@@ -62,6 +62,12 @@ class RodElement(Element):  # CROD, CONROD, CTUBE
         mass = (self.Rho() * self.Area() + self.Nsm()) * L
         return mass
 
+    def get_edges(self):
+        """
+        Return the edges
+        """
+        return [(self.nodes[0], self.nodes[1])]
+
 
 class CROD(RodElement):
     type = 'CROD'

--- a/pyNastran/bdf/cards/elements/shell.py
+++ b/pyNastran/bdf/cards/elements/shell.py
@@ -938,12 +938,10 @@ class QuadShell(ShellElement):
         """
         Returns the edges
         """
-        return [
-            (self.nodes[0], self.nodes[1]),
-            (self.nodes[1], self.nodes[2]),
-            (self.nodes[2], self.nodes[3]),
-            (self.nodes[3], self.nodes[0]),
-        ]
+        return [(self.nodes[0], self.nodes[1]),
+                (self.nodes[1], self.nodes[2]),
+                (self.nodes[2], self.nodes[3]),
+                (self.nodes[3], self.nodes[0])]
 
     def Thickness(self):
         """


### PR DESCRIPTION
I've seen the importance of an Edge object such as:

    class Edge(object):
        def __init__(self):
            self.nodes = set()
            self.elements = set()

to check the connectivity among elements in an algorithm like:

    # Finding edges
    mesh.edges = []
    for element in mesh.elements.values():
        el_edges = element.get_edges()
        for nodes in el_edges:
            nodes = set(nodes)
            is_new_edge = True
            for edge in mesh.edges:
                if nodes == edge.nodes:
                    is_new_edge = False
                    break
            if is_new_edge:
                new_edge = Edge()
                new_edge.nodes = set(nodes)
                new_edge.elements.add(element)
                mesh.edges.append(new_edge)
            else:
                edge.elements.add(element)

But for this approach to work the `LineElement` and `RodElement` should also have the method `get_edges` implemented, which is conceptually correct.

In this pull request I'm suggesting to add such methods.

If there is interest we could think of making this algorithm for edge detection shown above a new pull request.