### PR TITLE
Set default nu12 property for MAT8 card parser

### DIFF
--- a/pyNastran/bdf/cards/materials.py
+++ b/pyNastran/bdf/cards/materials.py
@@ -962,7 +962,7 @@ class MAT8(OrthotropicMaterial):
             self.mid = integer(card, 1, 'mid')
             self.e11 = double(card, 2, 'E11')    #: .. todo:: is this the correct default
             self.e22 = double(card, 3, 'E22')    #: .. todo:: is this the correct default
-            self.nu12 = double(card, 4, 'nu12')  #: .. todo:: is this the correct default
+            self.nu12 = double_or_blank(card, 4, 'nu12', 0.3)  #: .. todo:: is this the correct default
 
             self.g12 = double_or_blank(card, 5, 'g12', 0.0)
             self.g1z = double_or_blank(card, 6, 'g1z', 1e8)


### PR DESCRIPTION
Hello,

BDF reader fails if nu12 is omited in bdf file (generated by MSC.Patran). MSC Nastran documentation tells that nu12 is oprional parameter for MAT8 card definition.

It is proposed to introduce default dummy value to prevent failure of BDF reader.

Example of failed bdf MAT8 entries:

$ Material Record : mat8.4
$ Description of Material :
MAT8     4      10.     10.             2700.   2700.   2700.
$ Material Record : mat8.5
$ Description of Material :
MAT8     5      10.     10.             2700.   2700.   2700.
$ Material Record : mat8.6
$ Description of Material :
MAT8     6      100.    100.            2700.   2700.   2700.
$ Material Record : mat8.8
$ Description of Material :
MAT8     8      7200.   7200.           2700.   2700.   2700.

Proposed change was tested successfully.