### PR TITLE
Bug fix: The BDF method get_material_id_to_property_ids_map assumes a…

### DIFF
--- a/pyNastran/bdf/bdf_interface/get_card.py
+++ b/pyNastran/bdf/bdf_interface/get_card.py
@@ -485,6 +485,8 @@ class GetMethods(GetMethodsDeprecated, BDFAttributes):
                         if hasattr(prop, 'mid') and prop.Mid() in mids:
                             if pid not in mid_to_pids_map[mid]:
                                 mid_to_pids_map[mid].append(pid)
+            elif prop.type in ['PBUSH']:
+                pass
             else:
                 if hasattr(prop, 'Mids'):
                     mids = prop.Mids()


### PR DESCRIPTION
This is a possible fix to Issue  #288. I haven't really thought through if there are any potential pitfalls with this fix, but it seems to work for me for the time being.