### PR TITLE
BUG: get_node_positions() would'n work for bars and beam

### DIFF
--- a/pyNastran/bdf/cards/elements/bars.py
+++ b/pyNastran/bdf/cards/elements/bars.py
@@ -447,6 +447,8 @@ class CBAR(LineElement):
         self.ga_ref = self.ga
         self.gb = model.Node(self.gb, msg=msg)
         self.gb_ref = self.gb
+        self.nodes = model.Nodes([self.ga.nid, self.gb.nid], msg=msg)
+        self.nodes_ref = self.nodes
         self.pid = model.Property(self.pid, msg=msg)
         self.pid_ref = self.pid
         if model.is_nx:

--- a/pyNastran/bdf/cards/elements/beam.py
+++ b/pyNastran/bdf/cards/elements/beam.py
@@ -258,6 +258,8 @@ class CBEAM(CBAR):
         self.ga_ref = self.ga
         self.gb = model.Node(self.gb, msg=msg)
         self.gb_ref = self.gb
+        self.nodes = model.Nodes([self.ga.nid, self.gb.nid], msg=msg)
+        self.nodes_ref = self.nodes
         self.pid = model.Property(self.pid, msg=msg)
         self.pid_ref = self.pid
         if self.g0:


### PR DESCRIPTION
I was playing around with models mixing both shell and bar elements and got the following error when running `get_node_positions()`:

      File "C:\repos\pyNastran\pyNastran\bdf\cards\base_card.py", line 369, in get_node_positions
      nnodes = len(self.nodes_ref)
    AttributeError: 'CBAR' object has no attribute 'nodes_ref'


I believe the current pull request can fix this.