### PR TITLE
BUG: there was a bug with RSPLINE

### DIFF
--- a/pyNastran/bdf/cards/elements/rigid.py
+++ b/pyNastran/bdf/cards/elements/rigid.py
@@ -891,7 +891,7 @@ class RBE3(RigidElement):
 
         i = ioffset
         n = 1
-        weight_cg_group = []
+        #weight_cg_group = []
         weights = []
         comps = []
         Gijs = []
@@ -1133,7 +1133,10 @@ class RSPLINE(RigidElement):
         nids = []
         components = []
         j = 1
-        for i in range(3, nfields, 2):
+        nid = integer(card, 3, 'nid_%s' % j)
+        nids.append(nid)
+        j += 1
+        for i in range(4, nfields, 2):
             nid = integer(card, i, 'nid_%s' % j)
             comp = components_or_blank(card, i+1, 'components_%i' % j)
             nids.append(nid)


### PR DESCRIPTION
An additional node G1 wasn't being considered properly in the RSPLINE card.

The sequence is G1, G2, C2, G3, C3...

Before this fix it was doing G1, C1, G2, C2... (note that C1 does not exist, as per Nastran's QRG)