### PR TITLE
Fix for CAERO Buttons (Finally)

### DIFF
--- a/pyNastran/converters/nastran/nastranIOv.py
+++ b/pyNastran/converters/nastran/nastranIOv.py
@@ -168,20 +168,33 @@ class NastranIO(NastranGuiResults, NastranGeometryHelper):
         if not self.has_caero:
             return
         self.show_caero_actor = not self.show_caero_actor
+
+        names = ['caero', 'caero_subpanels', 'caero_control_surfaces']
+        geometry_properties = {}
+        for name in names:
+            try:
+                prop = self.geometry_properties[name]
+            except KeyError:
+                continue
+            geometry_properties[name] = prop
+
         if self.show_caero_actor:
+            try:
+                geometry_properties['caero_control_surfaces'].is_visible = True
+            except KeyError:
+                pass
             if self.show_caero_sub_panels:
-                self.geometry_actors['caero_subpanels'].VisibilityOn()
-                self.geometry_properties['caero_subpanels'].is_visble = True
+                geometry_properties['caero_subpanels'].is_visible = True
             else:
-                self.geometry_actors['caero'].VisibilityOn()
-                self.geometry_properties['caero'].is_visble = True
+                geometry_properties['caero'].is_visible = True
         else:
-            self.geometry_actors['caero'].VisibilityOff()
-            self.geometry_properties['caero'].is_visble = False
-            self.geometry_actors['caero_subpanels'].VisibilityOff()
-            self.geometry_properties['caero_subpanels'].is_visble = False
-            self.on_update_geometry_properties_window(self.geometry_properties)
-        self.vtk_interactor.Render()
+            try:
+                geometry_properties['caero_control_surfaces'].is_visible = False
+            except KeyError:
+                pass
+            geometry_properties['caero'].is_visible = False
+            geometry_properties['caero_subpanels'].is_visible = False
+        self.on_update_geometry_properties_override_dialog(geometry_properties)
 
     def on_update_geometry_properties_window(self, geometry_properties):
         if self._edit_geometry_properties_window_shown:
@@ -194,35 +207,37 @@ class NastranIO(NastranGuiResults, NastranGeometryHelper):
         """
         if not self.has_caero:
             return
+
+        names = ['caero', 'caero_subpanels']
+        geometry_properties = {}
+        for name in names:
+            try:
+                prop = self.geometry_properties[name]
+            except KeyError:
+                continue
+            geometry_properties[name] = prop
+
         self.show_caero_sub_panels = not self.show_caero_sub_panels
         if self.show_caero_actor:
             if self.show_caero_sub_panels:
-                self.geometry_actors['caero'].VisibilityOff()
-                self.geometry_properties['caero'].is_visble = False
-
-                self.geometry_actors['caero_subpanels'].VisibilityOn()
-                self.geometry_properties['caero_subpanels'].is_visble = True
+                geometry_properties['caero'].is_visible = False
+                geometry_properties['caero_subpanels'].is_visible = True
             else:
-                self.geometry_actors['caero'].VisibilityOn()
-                self.geometry_properties['caero'].is_visble = True
-
-                self.geometry_actors['caero_subpanels'].VisibilityOff()
-                self.geometry_properties['caero_subpanels'].is_visble = False
-        self.vtk_interactor.Render()
+                geometry_properties['caero'].is_visible = True
+                geometry_properties['caero_subpanels'].is_visible = False
+        self.on_update_geometry_properties_override_dialog(geometry_properties)
 
     def toggle_conms(self):
         """
         Toggle the visibility of the CONMS
         """
-        self.show_conm = not self.show_conm
-        if 'conm2' in self.geometry_actors:
-            if self.show_conm:
-                self.geometry_actors['conm2'].VisibilityOn()
-                self.geometry_properties['conm2'].is_visble = True
-            else:
-                self.geometry_actors['conm2'].VisibilityOff()
-                self.geometry_properties['conm2'].is_visble = False
-        self.vtk_interactor.Render()
+        name = 'conm2'
+        if name in self.geometry_actors:
+            geometry_properties_change = {name : self.geometry_properties[name]}
+            visibility_prev = geometry_properties_change[name].is_visible
+            geometry_properties_change[name].is_visible = not visibility_prev
+
+            self.on_update_geometry_properties_override_dialog(geometry_properties_change)
 
     def _create_coord(self, dim_max, cid, coord, cid_type):
         """

--- a/pyNastran/gui/gui_common.py
+++ b/pyNastran/gui/gui_common.py
@@ -5739,6 +5739,29 @@ class GuiCommon2(QMainWindow, GuiCommon):
             else:
                 raise NotImplementedError(geom_prop)
 
+    def on_update_geometry_properties_override_dialog(self, geometry_properties):
+        """
+        Update the goemetry properties and overwite the options in the edit geometry properties
+        dialog if it is open.
+
+        Parameters
+        -----------
+        geometry_properties : dict {str : CoordProperties or AltGeometry}
+            Dictionary from name to properties object. Only the names included in
+            ``geometry_properties`` are modified.
+
+        """
+        if self._edit_geometry_properties_window_shown:
+            # Overirde the output state in the edit geometry properties diaglog if the button is
+            # pushed while the dialog is open. This prevent the case where you close the dialog and
+            # the # state reverts back to before you hit the button.
+            for name, prop in iteritems(geometry_properties):
+                self._edit_geometry_properties.out_data[name] = prop
+                if self._edit_geometry_properties.active_key == name:
+                    index = self._edit_geometry_properties.table.currentIndex()
+                    self._edit_geometry_properties.update_active_key(index)
+        self.on_update_geometry_properties(geometry_properties)
+
     def on_set_modify_groups(self):
         """
         Opens a dialog box to set:

--- a/pyNastran/gui/menus/manage_actors.py
+++ b/pyNastran/gui/menus/manage_actors.py
@@ -386,12 +386,12 @@ class EditGeometryProperties(PyDialog):
         obj : CoordProperties, AltGeometry
             the storage object for things like line_width, point_size, etc.
         """
-        old_obj = self.out_data[self.active_key]
-        old_obj.line_width = self.line_width_edit.value()
-        old_obj.point_size = self.point_size_edit.value()
-        old_obj.bar_scale = self.bar_scale_edit.value()
-        old_obj.opacity = self.opacity_edit.value()
-        old_obj.is_visible = self.checkbox_show.isChecked()
+        #old_obj = self.out_data[self.active_key]
+        #old_obj.line_width = self.line_width_edit.value()
+        #old_obj.point_size = self.point_size_edit.value()
+        #old_obj.bar_scale = self.bar_scale_edit.value()
+        #old_obj.opacity = self.opacity_edit.value()
+        #old_obj.is_visible = self.checkbox_show.isChecked()
 
         if qt_version == 4:
             name = str(index.data().toString())


### PR DESCRIPTION
GUI
----
* Fixed the 'Show/Hide CAERO Panels', 'Toggle CAERO Subpanels', and 'Toggle CONM2s' button behavior in relation to the Edit Geometry Properties dialog.
* Added ``GuiCommon2.on_update_geometry_properties_override_dialog`` to update properties even when the dialog is open.
* Removed redundant calls to set the previous object properties in ``EditGeometryProperties.update_active_key``