### PR TITLE
Changing string to byte literal in Struct format

### DIFF
--- a/pyNastran/op2/op2_interface/op2_common.py
+++ b/pyNastran/op2/op2_interface/op2_common.py
@@ -1299,7 +1299,7 @@ class OP2Common(Op2Codes, F06Writer):
             pass
         else:
             n = 0
-            s = Struct(self._endian + self._analysis_code_fmt + 'i12f')
+            s = Struct(self._endian + self._analysis_code_fmt + b'i12f')
             binary_debug_fmt = '  %s=%s %%s\n' % (flag, flag_type)
             for unused_inode in range(nnodes):
                 edata = data[n:n+56]
@@ -1338,7 +1338,7 @@ class OP2Common(Op2Codes, F06Writer):
         else:
             n = 0
             #ntotal = 56  # 14 * 4
-            s = Struct(self._endian + self._analysis_code_fmt + 'i12f')
+            s = Struct(self._endian + self._analysis_code_fmt + b'i12f')
             assert self.obj is not None
             assert nnodes > 0
             #assert ndata % ntotal == 0


### PR DESCRIPTION
The attributes `self._endian` and `self_analysis_code_fmt` are bytes so an exception is thrown because of concatenating a byte with a string.