### PR TITLE
Update field_writer_8.py

### DIFF
--- a/pyNastran/bdf/field_writer_8.py
+++ b/pyNastran/bdf/field_writer_8.py
@@ -116,7 +116,8 @@ def print_float_8(value: float) -> str:
         #elif value < 0.1:
             #field = "%8.7f" % value
         elif value < 1.:
-            field = "%8.7f" % value  # same as before...
+            dummy = "%8.7f" % value  # same as before...
+            field = dummy[1:]
         elif value < 10.:
             field = "%8.6f" % value
         elif value < 100.:


### PR DESCRIPTION
Shouldn't the float-string for values between 0 < x < 1 be as proposed in line 120?

if value = 0.5, then `'%8.7f' % value`  gives '0.5000000'. That's 9 characters.

Changing the code to `return string[1:]` then returns 8 characters 