### PR TITLE
Bugfix: BDF, BGSET card field reading

### DIFF
--- a/pyNastran/bdf/cards/contact.py
+++ b/pyNastran/bdf/cards/contact.py
@@ -1795,7 +1795,7 @@ class BGSET(BaseCard):
             exts.append(double_or_blank(card, i + 4, 'mind%s' % j, 0.0))
             #else:
                 #exts.append(None)
-            i += 8
+            i += 10
             j += 1
         return BGSET(glue_id, sids, tids, sdists, exts,
                      comment=comment, sol=sol)

--- a/pyNastran/bdf/cards/contact.py
+++ b/pyNastran/bdf/cards/contact.py
@@ -1792,7 +1792,7 @@ class BGSET(BaseCard):
             tids.append(integer(card, i + 1, 'tid%s' % j))
             sdists.append(double_or_blank(card, i + 2, 'fric%s' % j, 0.0))
             #if sol == 101:
-            exts.append(double_or_blank(card, i + 3, 'mind%s' % j, 0.0))
+            exts.append(double_or_blank(card, i + 4, 'mind%s' % j, 0.0))
             #else:
                 #exts.append(None)
             i += 8


### PR DESCRIPTION
The BGSET card format looks like this:

![image](https://user-images.githubusercontent.com/47860277/231722523-753aba54-ae00-4d58-aad5-81b55a7b15d1.png)

Therefore, EXTj should be read from fields i+4 with i=2+10*(j-1), instead of the current i+3 and i=2+8*(j-1).