### PR TITLE
CHEXA composite stress now correctly set by @setter in OP2 results.

### DIFF
--- a/pyNastran/op2/op2_interface/op2_f06_common.py
+++ b/pyNastran/op2/op2_interface/op2_f06_common.py
@@ -699,8 +699,8 @@ class OP2_F06_Common:
     def cpyram_stress(self, cpyram_stress):
         self.op2_results.stress.cpyram_stress = cpyram_stress
 
-    @chexa_stress.setter
-    def chexa_composite_stress(self):
+    @chexa_composite_stress.setter
+    def chexa_composite_stress(self, chexa_composite_stress):
         self.op2_results.stress.chexa_composite_stress = chexa_composite_stress
     @cpenta_composite_stress.setter
     def cpenta_composite_stress(self, cpenta_composite_stress):


### PR DESCRIPTION
The CHEXA composite stresses were not set by its setter because the setter took no arguments. Additionally, the setter referred to the wrong variable to set (chexa_stress instead of chexa_composite_stress).