### PR TITLE
Add matcid card to bdf

### DIFF
--- a/pyNastran/bdf/bdf.py
+++ b/pyNastran/bdf/bdf.py
@@ -102,7 +102,8 @@ from .cards.properties.mass import PMASS, NSM, NSM1, NSML, NSML1, NSMADD
 from .cards.constraints import (SPC, SPCADD, SPCAX, SPC1, SPCOFF, SPCOFF1,
                                 MPC, MPCADD, SUPORT1, SUPORT, SESUP,
                                 GMSPC)
-from .cards.coordinate_systems import (CORD1R, CORD1C, CORD1S,
+from .cards.coordinate_systems import (MATCID,
+                                       CORD1R, CORD1C, CORD1S,
                                        CORD2R, CORD2C, CORD2S, #CORD3G,
                                        transform_coords_vectorized,
                                        CORDx)
@@ -755,6 +756,8 @@ class BDF_(BDFMethods, GetCard, AddCards, WriteMeshs, UnXrefMesh):
             ## coords
             'CORD1R', 'CORD1C', 'CORD1S',
             'CORD2R', 'CORD2C', 'CORD2S',
+
+            'MATCID',
 
             # temperature cards
             'TEMP', 'TEMPD', 'TEMPB3', 'TEMPAX',
@@ -2160,6 +2163,8 @@ class BDF_(BDFMethods, GetCard, AddCards, WriteMeshs, UnXrefMesh):
             'CORD2R' : (CORD2R, add_methods._add_coord_object),
             'CORD2C' : (CORD2C, add_methods._add_coord_object),
             'CORD2S' : (CORD2S, add_methods._add_coord_object),
+
+            'MATCID' : (MATCID, add_methods._add_matcid_object),
 
             # parametric
             'PSET' : (PSET, add_methods._add_pset),

--- a/pyNastran/bdf/bdf_interface/add_card.py
+++ b/pyNastran/bdf/bdf_interface/add_card.py
@@ -66,7 +66,8 @@ from pyNastran.bdf.cards.constraints import (SPC, SPCADD, SPCAX, SPC1, SPCOFF, S
                                              MPC, MPCADD, SUPORT1, SUPORT, SESUP,
                                              GMSPC)
 from pyNastran.bdf.cards.coordinate_systems import (CORD1R, CORD1C, CORD1S,
-                                                    CORD2R, CORD2C, CORD2S, CORD3G)
+                                                    CORD2R, CORD2C, CORD2S, CORD3G,
+                                                    MATCID,)
 from pyNastran.bdf.cards.deqatn import DEQATN
 from pyNastran.bdf.cards.dynamic import (
     DELAY, DPHASE, FREQ, FREQ1, FREQ2, FREQ3, FREQ4, FREQ5,
@@ -240,6 +241,8 @@ CARD_MAP = {
     'CORD2R' : CORD2R,
     'CORD2C' : CORD2C,
     'CORD2S' : CORD2S,
+
+    'MATCID': MATCID,
 
     # msgmesh
     #'GMCORD' : GMCORD,
@@ -876,6 +879,73 @@ class AddCards:
         point = POINT(nid, xyz, cp=cp, comment=comment)
         self._add_methods._add_point_object(point)
         return point
+
+    def add_matcid(self, cid: int,
+                   eids,
+                   all_eids: bool,
+                   thru: Optional[int],
+                   by: Optional[int],
+                   comment: str='') -> MATCID:
+        """
+        Creates the MATCID card, which defines the Material Coordinate System for Solid Elements
+
+        -Overrides the material coordinate system for CHEXA, CPENTA, CTETRA, and CPYRAM solid elements when the elements
+        reference a PSOLID property.
+
+        -Overrides the material coordinate system for CHEXA and CPENTA solid elements when
+        the elements reference a PCOMPS property.
+
+        -Overrides the material coordinate system for CHEXCZ and CPENTCZ solid elements.
+
+        Parameters
+        ----------
+        cid : int
+            coordinate system id
+        eids : array[int, ...]
+            Array of element identification numbers
+        all_eids : bool
+            True if MATCID points to "ALL" EIDs in format alternative 4
+        thru : int
+            used in format alternative 2 and 3
+        by : int
+            used in format alternative 3
+        comment : str; default=''
+            a comment for the card
+
+        Format (alternative 1):
+            +--------+-------+--------+-------+-------+------+------+------+------+
+            |   1    |   2   |    3   |  4    |  5    |  6   |  7   |   8  |  9   |
+            +========+=======+========+=======+=======+======+======+======+======+
+            | MATCID |  CID  | EID1   | EID2  | EID3  | EID4 | EID5 | EID6 | EID7 |
+            +--------+-------+--------+-------+-------+------+------+------+------+
+            |        | EID8  | EID9   | -etc- |       |      |      |      |      |
+            +--------+-------+--------+-------+-------+------+------+------+------+
+
+        Format (alternative 2):
+            +--------+-------+--------+--------+------+------+------+------+------+
+            |   1    |   2   |    3   |   4    |  5   |  6   |  7   |   8  |  9   |
+            +========+=======+========+========+======+======+======+======+======+
+            | MATCID |  CID  | EID1   | "THRU" | EID2 |      |      |      |      |
+            +--------+-------+--------+--------+------+------+------+------+------+
+
+        Format (alternative 3):
+            +--------+-------+--------+--------+-------+------+------+------+------+
+            |   1    |   2   |    3   |  4    |  5    |  6   |   7   |   8  |  9   |
+            +========+=======+========+========+=======+======+======+======+======+
+            | MATCID |  CID  | EID1   | "THRU" | EID2  | "BY" |  N   |      |      |
+            +--------+-------+--------+--------+-------+------+------+------+------+
+
+        Format (alternative 4):
+            +--------+-------+--------+-------+-------+------+------+------+------+
+            |   1    |   2   |    3   |  4    |  5    |  6   |  7   |   8  |  9   |
+            +========+=======+========+=======+=======+======+======+======+======+
+            | MATCID |  CID  | "ALL"  |       |       |      |      |      |      |
+            +--------+-------+--------+-------+-------+------+------+------+------+
+        """
+
+        matcid = MATCID(cid, eids, all_eids, thru, by, comment=comment)
+        self._add_methods._add_matcid_object(matcid)
+        return matcid
 
     def add_cord2r(self, cid: int,
                    origin: Optional[Union[list[float], NDArray3float]],

--- a/pyNastran/bdf/bdf_interface/add_card.py
+++ b/pyNastran/bdf/bdf_interface/add_card.py
@@ -880,11 +880,9 @@ class AddCards:
         self._add_methods._add_point_object(point)
         return point
 
-    def add_matcid(self, cid: int,
-                   eids,
-                   all_eids: bool,
-                   thru: Optional[int],
-                   by: Optional[int],
+    def add_matcid(self, cid: int, form: int,
+                   eids = None,
+                   start: Optional[int] = None, thru: Optional[int] = None, by: Optional[int] = None,
                    comment: str='') -> MATCID:
         """
         Creates the MATCID card, which defines the Material Coordinate System for Solid Elements
@@ -901,10 +899,12 @@ class AddCards:
         ----------
         cid : int
             coordinate system id
+        form: int
+            integer indicating the format alternative (for reference, see the 4 different formats below)
         eids : array[int, ...]
             Array of element identification numbers
-        all_eids : bool
-            True if MATCID points to "ALL" EIDs in format alternative 4
+        start: int
+            used in format alternative 2 and 3, indicates starting eID
         thru : int
             used in format alternative 2 and 3
         by : int

--- a/pyNastran/bdf/bdf_interface/add_card.py
+++ b/pyNastran/bdf/bdf_interface/add_card.py
@@ -943,7 +943,7 @@ class AddCards:
             +--------+-------+--------+-------+-------+------+------+------+------+
         """
 
-        matcid = MATCID(cid, eids, all_eids, thru, by, comment=comment)
+        matcid = MATCID(cid, form, start, thru, by, comment=comment)
         self._add_methods._add_matcid_object(matcid)
         return matcid
 

--- a/pyNastran/bdf/bdf_interface/add_card.py
+++ b/pyNastran/bdf/bdf_interface/add_card.py
@@ -943,7 +943,7 @@ class AddCards:
             +--------+-------+--------+-------+-------+------+------+------+------+
         """
 
-        matcid = MATCID(cid, form, start, thru, by, comment=comment)
+        matcid = MATCID(cid, form, eids, start, thru, by, comment=comment)
         self._add_methods._add_matcid_object(matcid)
         return matcid
 

--- a/pyNastran/bdf/bdf_interface/add_methods.py
+++ b/pyNastran/bdf/bdf_interface/add_methods.py
@@ -862,19 +862,16 @@ class AddMethods:
             self.model.coords[key] = coord
             self.model._type_to_id_map[coord.type].append(key)
 
-    def _add_matcid_object(self, matcid: Union[MATCID],
-                          allow_overwrites: bool=False) -> None:
+    def _add_matcid_object(self, matcid: Union[MATCID]) -> None:
         """adds a MATCID object"""
         key = matcid.cid
         assert matcid.cid > -1, 'cid=%s coord=\n%s' % (key, matcid)
 
-        # Multiple MATCIDs can share the same CID.
-        # Combine their eids together in a single MATCID
+        # Multiple MATCIDs can share the same CID
         if key in self.model.MATCID:
-            self.model.MATCID[key].combine_eids(matcid)
-
+            self.model.MATCID[key].append(matcid)
         else:
-            self.model.MATCID[key] = matcid
+            self.model.MATCID[key] = [matcid]
             self.model._type_to_id_map[matcid.type].append(key)
 
     def _add_load_combination_object(self, load: Union[LOAD, CLOAD]) -> None:

--- a/pyNastran/bdf/bdf_interface/add_methods.py
+++ b/pyNastran/bdf/bdf_interface/add_methods.py
@@ -58,6 +58,7 @@ if TYPE_CHECKING:  # pragma: no cover
                                                  GMSPC)
     from pyNastran.bdf.cards.coordinate_systems import (CORD1R, CORD1C, CORD1S,
                                                         CORD2R, CORD2C, CORD2S, #CORD3G,
+                                                        MATCID,
                                                         )
     from pyNastran.bdf.cards.deqatn import DEQATN
     from pyNastran.bdf.cards.dynamic import (
@@ -860,6 +861,21 @@ class AddMethods:
         else:
             self.model.coords[key] = coord
             self.model._type_to_id_map[coord.type].append(key)
+
+    def _add_matcid_object(self, matcid: Union[MATCID],
+                          allow_overwrites: bool=False) -> None:
+        """adds a MATCID object"""
+        key = matcid.cid
+        assert matcid.cid > -1, 'cid=%s coord=\n%s' % (key, matcid)
+
+        # Multiple MATCIDs can share the same CID.
+        # Combine their eids together in a single MATCID
+        if key in self.model.MATCID:
+            self.model.MATCID[key].combine_eids(matcid)
+
+        else:
+            self.model.MATCID[key] = matcid
+            self.model._type_to_id_map[matcid.type].append(key)
 
     def _add_load_combination_object(self, load: Union[LOAD, CLOAD]) -> None:
         """adds a load object to a load case"""

--- a/pyNastran/bdf/bdf_interface/attributes.py
+++ b/pyNastran/bdf/bdf_interface/attributes.py
@@ -498,6 +498,7 @@ class BDFAttributes:
         xzplane = array([1., 0., 0.])
         coord = CORD2R(cid=0, rid=0, origin=origin, zaxis=zaxis, xzplane=xzplane)
         self.coords = {0 : coord}   # type: dict[int, Any]
+        self.MATCID = {}
 
         # --------------------------- constraints ----------------------------
         #: stores SUPORT1s
@@ -947,6 +948,7 @@ class BDFAttributes:
             'coords' : ['CORD1R', 'CORD1C', 'CORD1S',
                         'CORD2R', 'CORD2C', 'CORD2S',
                         'GMCORD', 'ACOORD', 'CORD3G'],
+            'matcid': ['MATCID'],
 
             # temperature cards
             'tempds' : ['TEMPD'],

--- a/pyNastran/bdf/bdf_interface/stats.py
+++ b/pyNastran/bdf/bdf_interface/stats.py
@@ -40,7 +40,7 @@ def get_bdf_stats(model: BDF, return_type: str='string',
         'materials', 'creep_materials', 'hyperelastic_materials',
         'MATT1', 'MATT2', 'MATT3', 'MATT4', 'MATT5', 'MATT8', 'MATT9',
         'MATS1', 'MATS3', 'MATS8', 'MATT8',
-        'coords', 'mpcs',
+        'coords', 'mpcs', 'MATCID',
 
         # axisysmmetric
 

--- a/pyNastran/bdf/bdf_interface/write_mesh.py
+++ b/pyNastran/bdf/bdf_interface/write_mesh.py
@@ -600,11 +600,12 @@ class WriteMesh(BDFAttributes):
 
         if len(self.MATCID):
             bdf_file.write('$MATCID\n')
-        for (cid, matcid) in sorted(self.MATCID.items()):
-            try:
-                bdf_file.write(matcid.write_card(size, is_double))
-            except RuntimeError:
-                bdf_file.write(matcid.write_card_16(is_double))
+        for (cid, matcids) in sorted(self.MATCID.items()):
+            for matcid in matcids:
+                try:
+                    bdf_file.write(matcid.write_card(size, is_double))
+                except RuntimeError:
+                    bdf_file.write(matcid.write_card_16(is_double))
 
     def _write_dmigs(self, bdf_file: Any, size: int=8, is_double: bool=False,
                      is_long_ids: Optional[bool]=None) -> None:

--- a/pyNastran/bdf/bdf_interface/write_mesh.py
+++ b/pyNastran/bdf/bdf_interface/write_mesh.py
@@ -496,6 +496,7 @@ class WriteMesh(BDFAttributes):
         self._write_parametric(bdf_file, size, is_double, is_long_ids=is_long_ids)
         self._write_rejects(bdf_file, size, is_double, is_long_ids=is_long_ids)
         self._write_coords(bdf_file, size, is_double, is_long_ids=is_long_ids)
+        self._write_matcids(bdf_file, size, is_double, is_long_ids=is_long_ids)
 
         if self.acmodl:
             bdf_file.write(self.acmodl.write_card(size, is_double))
@@ -591,6 +592,19 @@ class WriteMesh(BDFAttributes):
                 bdf_file.write(coord.write_card(size, is_double))
             except RuntimeError:
                 bdf_file.write(coord.write_card_16(is_double))
+
+    def _write_matcids(self, bdf_file: Any, size: int=8, is_double: bool=False,
+                      is_long_ids: Optional[bool]=None) -> None:
+        """Writes the MATCID cards in a sorted order"""
+        size, is_long_ids = self._write_mesh_long_ids_size(size, is_long_ids)
+
+        if len(self.MATCID):
+            bdf_file.write('$MATCID\n')
+        for (cid, matcid) in sorted(self.MATCID.items()):
+            try:
+                bdf_file.write(matcid.write_card(size, is_double))
+            except RuntimeError:
+                bdf_file.write(matcid.write_card_16(is_double))
 
     def _write_dmigs(self, bdf_file: Any, size: int=8, is_double: bool=False,
                      is_long_ids: Optional[bool]=None) -> None:

--- a/pyNastran/bdf/cards/coordinate_systems.py
+++ b/pyNastran/bdf/cards/coordinate_systems.py
@@ -8,6 +8,7 @@ All coordinate cards are defined in this file.  This includes:
  * CORD2R
  * CORD2C
  * CORD2S
+ * MATCID
 
 {ug} = [Tgb]{ub}
 {ub} = [Tbg]{ug}
@@ -24,11 +25,12 @@ from numpy.linalg import norm  # type: ignore
 if TYPE_CHECKING:  # pragma: no cover
     from pyNastran.nptyping_interface import NDArray3float
     from pyNastran.bdf.bdf import BDF
+    from typing import Optional
 from pyNastran.utils.numpy_utils import integer_types
 from pyNastran.bdf.field_writer_8 import set_blank_if_default
 from pyNastran.bdf.cards.base_card import BaseCard
 from pyNastran.bdf.bdf_interface.assign_type import (
-    integer, integer_or_blank, double_or_blank, string_or_blank)
+    integer, integer_or_blank, double_or_blank, string_or_blank, integer_or_string)
 from pyNastran.bdf.field_writer_8 import print_card_8
 from pyNastran.bdf.field_writer_16 import print_card_16
 from pyNastran.bdf.field_writer_double import print_card_double
@@ -1255,6 +1257,228 @@ def define_coord_ijk(model, cord2_type, cid, origin, rid=0, i=None, j=None, k=No
     if add:
         model._add_methods._add_coord_object(coord)
     return coord
+
+
+class MATCID():
+    """
+    TODO: Explanation
+    """
+    type = 'MATCID'
+    # Type = 'M'
+
+    def __init__(self, cid, eids=None,
+                 all_eids: bool = False,
+                 thru: Optional[int] = None, by: Optional[int] = None,
+                 comment=''):
+        """
+        Creates the MATCID card, which defines the Material Coordinate System for Solid Elements
+
+        -Overrides the material coordinate system for CHEXA, CPENTA, CTETRA, and CPYRAM solid elements when the elements
+        reference a PSOLID property.
+
+        -Overrides the material coordinate system for CHEXA and CPENTA solid elements when
+        the elements reference a PCOMPS property.
+
+        -Overrides the material coordinate system for CHEXCZ and CPENTCZ solid elements.
+
+        Parameters
+        ----------
+        cid : int
+            coordinate system id
+        eids : array[int, ...]
+            Array of element identification numbers
+        all_eids : bool
+            True if MATCID points to "ALL" EIDs in format alternative 4
+        thru : int
+            used in format alternative 2 and 3
+        by : int
+            used in format alternative 3
+        comment : str; default=''
+            a comment for the card
+
+        Format (alternative 1):
+            +--------+-------+--------+-------+-------+------+------+------+------+
+            |   1    |   2   |    3   |  4    |  5    |  6   |  7   |   8  |  9   |
+            +========+=======+========+=======+=======+======+======+======+======+
+            | MATCID |  CID  | EID1   | EID2  | EID3  | EID4 | EID5 | EID6 | EID7 |
+            +--------+-------+--------+-------+-------+------+------+------+------+
+            |        | EID8  | EID9   | -etc- |       |      |      |      |      |
+            +--------+-------+--------+-------+-------+------+------+------+------+
+
+        Format (alternative 2):
+            +--------+-------+--------+--------+------+------+------+------+------+
+            |   1    |   2   |    3   |   4    |  5   |  6   |  7   |   8  |  9   |
+            +========+=======+========+========+======+======+======+======+======+
+            | MATCID |  CID  | EID1   | "THRU" | EID2 |      |      |      |      |
+            +--------+-------+--------+--------+------+------+------+------+------+
+
+        Format (alternative 3):
+            +--------+-------+--------+--------+-------+------+------+------+------+
+            |   1    |   2   |    3   |  4    |  5    |  6   |   7   |   8  |  9   |
+            +========+=======+========+========+=======+======+======+======+======+
+            | MATCID |  CID  | EID1   | "THRU" | EID2  | "BY" |  N   |      |      |
+            +--------+-------+--------+--------+-------+------+------+------+------+
+
+        Format (alternative 4):
+            +--------+-------+--------+-------+-------+------+------+------+------+
+            |   1    |   2   |    3   |  4    |  5    |  6   |  7   |   8  |  9   |
+            +========+=======+========+=======+=======+======+======+======+======+
+            | MATCID |  CID  | "ALL"  |       |       |      |      |      |      |
+            +--------+-------+--------+-------+-------+------+------+------+------+
+        """
+        self.cid = cid
+        self.eids = eids
+        self.all_eids = all_eids
+        self.all = all
+        self.thru = thru  # End eid
+        self.by = by  # Skip factor
+        self.comment = comment
+
+    @classmethod
+    def add_card(cls, card, comment=''):
+        """
+        Material Coordinate System for Solid Elements
+
+        -Overrides the material coordinate system for CHEXA, CPENTA, CTETRA, and CPYRAM solid elements when the elements
+        reference a PSOLID property.
+
+        -Overrides the material coordinate system for CHEXA and CPENTA solid elements when
+        the elements reference a PCOMPS property.
+
+        -Overrides the material coordinate system for CHEXCZ and CPENTCZ solid elements.
+
+        Format (alternative 1):
+            +--------+-------+--------+-------+-------+------+------+------+------+
+            |   1    |   2   |    3   |  4    |  5    |  6   |  7   |   8  |  9   |
+            +========+=======+========+=======+=======+======+======+======+======+
+            | MATCID |  CID  | EID1   | EID2  | EID3  | EID4 | EID5 | EID6 | EID7 |
+            +--------+-------+--------+-------+-------+------+------+------+------+
+            |        | EID8  | EID9   | -etc- |       |      |      |      |      |
+            +--------+-------+--------+-------+-------+------+------+------+------+
+
+        Format (alternative 2):
+            +--------+-------+--------+--------+------+------+------+------+------+
+            |   1    |   2   |    3   |   4    |  5   |  6   |  7   |   8  |  9   |
+            +========+=======+========+========+======+======+======+======+======+
+            | MATCID |  CID  | EID1   | "THRU" | EID2 |      |      |      |      |
+            +--------+-------+--------+--------+------+------+------+------+------+
+
+        Format (alternative 3):
+            +--------+-------+--------+--------+-------+------+------+------+------+
+            |   1    |   2   |    3   |  4    |  5    |  6   |   7   |   8  |  9   |
+            +========+=======+========+========+=======+======+======+======+======+
+            | MATCID |  CID  | EID1   | "THRU" | EID2  | "BY" |  N   |      |      |
+            +--------+-------+--------+--------+-------+------+------+------+------+
+
+        Format (alternative 4):
+            +--------+-------+--------+-------+-------+------+------+------+------+
+            |   1    |   2   |    3   |  4    |  5    |  6   |  7   |   8  |  9   |
+            +========+=======+========+=======+=======+======+======+======+======+
+            | MATCID |  CID  | "ALL"  |       |       |      |      |      |      |
+            +--------+-------+--------+-------+-------+------+------+------+------+
+        """
+
+        #: coordinate system ID
+        cid = integer(card, 1, 'cid')
+        all_eids = False
+
+        data_length = len(card)
+
+        if data_length > 3:  # More than 1 eID referenced
+
+            pos3 = integer_or_string(card, 3, 'pos3')
+            if type(pos3) is str:  # THRU
+
+                by = 1
+                if data_length > 5: # BY
+
+                    by = integer_or_blank(card, 6, 'skip_factor', 1)
+                    thru = integer(card, 4, 'eid_end')
+                    start_id = integer(card, 2, 'eid_start')
+                    eids = np.arange(start_id, thru+1, by)
+                    return cls(cid, eids, comment=comment)
+
+                thru = integer(card, 4, 'eid_end')
+                start_id = integer(card, 2, 'eid_start')
+                eids = np.arange(start_id, thru + 1, by)
+                return cls(cid, eids, comment=comment)
+
+            else:
+                eids = np.empty([data_length])
+
+                index = 0
+                for i in range(2, data_length+1):
+                    eids[index] = integer(card, i, 'eid')
+                    index += 1
+
+                return cls(cid, eids, comment=comment)
+
+        else:  # Only 1 eID referenced or "ALL"
+            pos2 = integer_or_string(card, 2, 'pos2')
+            if type(pos2) is str:
+                all_eids = True
+                eids = None
+                return cls(cid, eids, all_eids, comment=comment)
+            else:
+                eids = np.array([integer(card, 2, 'eid1')])
+                return cls(cid, eids, comment=comment)
+
+    def combine_eids(self, matcid) -> None:
+        """
+        Concatenates the eids of both MATCID cards.
+        """
+
+        assert self.all_eids is False, f"all={self.all_eids}, {self}"
+        assert matcid.all_eids is False, f"all={matcid.all_eids}, {matcid}"
+
+        self.eids = np.concatenate((self.eids, matcid.eids))
+
+    def Cid(self) -> int:
+        return self.cid
+
+    def write_card(self, size: int=8, is_double: bool=False) -> str:
+        card = self.repr_fields()
+        if size == 8:
+            return self.comment + print_card_8(card)
+        elif is_double:
+            return self.comment + print_card_double(card)
+        return self.comment + print_card_16(card)
+
+    def write_card_16(self, is_double: bool=False) -> str:
+        """Writes a MATCID card in 16-field format"""
+        card = self.repr_fields()
+        if is_double:
+            return self.comment + print_card_double(card)
+        return self.comment + print_card_16(card)
+
+    def repr_fields(self):
+        return self.raw_fields()
+
+    def raw_fields(self):
+        if self.thru is not None:
+            if self.by is not None:
+                return ['MATCID', self.cid, self.eids[0], 'THRU', self.thru, 'BY', self.by]
+            else:
+                return ['MATCID', self.cid, self.eids[0], 'THRU', self.thru]
+        if self.all_eids is True:
+            return ['MATCID', self.cid, 'ALL']
+        else:
+            return ['MATCID', self.cid] + list(self.eids)
+
+    # Not working
+    def _verify(self, xref):
+        """
+        Verifies all methods for this object work
+
+        Parameters
+        ----------
+        xref : bool
+            has this model been cross referenced
+
+        """
+
+        cid = self.Cid()
+        assert isinstance(cid, integer_types), 'cid=%r' % cid
 
 
 class RectangularCoord:

--- a/pyNastran/bdf/cards/coordinate_systems.py
+++ b/pyNastran/bdf/cards/coordinate_systems.py
@@ -1483,9 +1483,9 @@ class MATCID:
                         return cls(cid, form, None, start, thru, None, comment=comment)
                 else:  # Multiple eIDs referenced without using THRU / BY
                     form = 1
-                    eids = np.empty([n_fields - 2])
-                    for i in range(2, n_fields + 1):
-                        eids[i] = integer(card, i, 'eid')
+                    eids = np.empty([n_fields - 2], dtype=int)
+                    for i in range(2, n_fields):
+                        eids[i-2] = integer(card, i, 'eid')
                     return cls(cid, form, eids, None, None, None, comment=comment)
 
             else:  # Single eID referenced

--- a/pyNastran/bdf/cards/test/test_coords.py
+++ b/pyNastran/bdf/cards/test/test_coords.py
@@ -1019,7 +1019,7 @@ class TestCoords(unittest.TestCase):
             cids)
         make_monpnt1s_from_cids(model, nids, cids, cid_to_inids)
         #model.write_bdf('spike.bdf')
-
+        
 def make_tri(model):
     model.add_grid(1, [0., 0., 0.])
     model.add_grid(3, [0., 0., 1.])

--- a/pyNastran/bdf/cards/test/test_coords.py
+++ b/pyNastran/bdf/cards/test/test_coords.py
@@ -1019,6 +1019,140 @@ class TestCoords(unittest.TestCase):
             cids)
         make_monpnt1s_from_cids(model, nids, cids, cid_to_inids)
         #model.write_bdf('spike.bdf')
+
+    def test_matcid(self):
+        """
+        Tests whether the correct card format is specified, and whether the fields are correctly read and assigned
+        to the MATCID card.
+
+        Format (alternative 1):
+            +--------+-------+--------+-------+-------+------+------+------+------+
+            |   1    |   2   |    3   |  4    |  5    |  6   |  7   |   8  |  9   |
+            +========+=======+========+=======+=======+======+======+======+======+
+            | MATCID |  CID  | EID1   | EID2  | EID3  | EID4 | EID5 | EID6 | EID7 |
+            +--------+-------+--------+-------+-------+------+------+------+------+
+            |        | EID8  | EID9   | -etc- |       |      |      |      |      |
+            +--------+-------+--------+-------+-------+------+------+------+------+
+
+        Format (alternative 2):
+            +--------+-------+--------+--------+------+------+------+------+------+
+            |   1    |   2   |    3   |   4    |  5   |  6   |  7   |   8  |  9   |
+            +========+=======+========+========+======+======+======+======+======+
+            | MATCID |  CID  | EID1   | "THRU" | EID2 |      |      |      |      |
+            +--------+-------+--------+--------+------+------+------+------+------+
+
+        Format (alternative 3):
+            +--------+-------+--------+--------+-------+------+------+------+------+
+            |   1    |   2   |    3   |  4    |  5    |  6   |   7   |   8  |  9   |
+            +========+=======+========+========+=======+======+======+======+======+
+            | MATCID |  CID  | EID1   | "THRU" | EID2  | "BY" |  N   |      |      |
+            +--------+-------+--------+--------+-------+------+------+------+------+
+
+        Format (alternative 4):
+            +--------+-------+--------+-------+-------+------+------+------+------+
+            |   1    |   2   |    3   |  4    |  5    |  6   |  7   |   8  |  9   |
+            +========+=======+========+=======+=======+======+======+======+======+
+            | MATCID |  CID  | "ALL"  |       |       |      |      |      |      |
+            +--------+-------+--------+-------+-------+------+------+------+------+
+        """
+
+        mid = 2
+        pid = 4
+
+        cids = [7, 8, 9, 10]
+
+        cards = [
+            ['GRID', 11, 0, 0., 0., 0., 0],
+            ['GRID', 12, 0, 1., 0., 0., 0],
+            ['GRID', 13, 0, 1., 1., 0., 0],
+            ['GRID', 14, 0, 0., 1., 0., 0],
+
+            ['GRID', 15, 0, 0., 0., 2., 0],
+            ['GRID', 16, 0, 1., 0., 2., 0],
+            ['GRID', 17, 0, 1., 1., 2., 0],
+            ['GRID', 18, 0, 0., 1., 2., 0],
+
+            ['CHEXA', 7, pid, 11, 12, 13, 14, 15, 16, 17, 18],
+            ['CHEXA', 8, pid, 12, 13, 14, 15, 16, 17, 18, 11],
+            ['CHEXA', 9, pid, 13, 14, 15, 16, 17, 18, 11, 12],
+            ['CHEXA', 10, pid, 14, 15, 16, 17, 18, 11, 12, 13],
+
+            ['CHEXA', 11, pid, 15, 16, 17, 18, 11, 12, 13, 14],
+            ['CHEXA', 12, pid, 16, 17, 18, 11, 12, 13, 14, 15],
+            ['CHEXA', 13, pid, 17, 18, 11, 12, 13, 14, 15, 16],
+            ['CHEXA', 14, pid, 18, 11, 12, 13, 14, 15, 16, 17],
+
+            ['PSOLID', pid, mid, 0],
+
+            ['MAT1', mid, 1.0, 2.0, 3.0, 0.1],
+
+            ['CORD2R', cids[0], None, 1.135, 0.089237, -0.0676, 0.135, 0.089237, -0.0676,
+             1.135, 0.089237, 0.9324],
+            ['CORD2R', cids[1], None, 1.135, 0.089237, -0.0676, 0.135, 0.089237, -0.0676,
+             1.135, 0.089237, 0.9324],
+            ['CORD2R', cids[2], None, 1.135, 0.089237, -0.0676, 0.135, 0.089237, -0.0676,
+             1.135, 0.089237, 0.9324],
+            ['CORD2R', cids[3], None, 1.135, 0.089237, -0.0676, 0.135, 0.089237, -0.0676,
+             1.135, 0.089237, 0.9324],
+
+            # MATCID Variants
+            ['MATCID', cids[0], 7, 8, 9, 10, 11, 12, 13, 14],  # Manual
+            ['MATCID', cids[1], 7, 'THRU', 14],  # Using 'THRU'
+            ['MATCID', cids[2], 7, 'THRU', 14, 'BY', 1],  # Using 'BY'
+            ['MATCID', cids[3], 'ALL'],  # Using 'ALL'
+            ]
+
+        model = BDF(debug=False)
+        for fields in cards:
+            model.add_card(fields, fields[0], is_list=True)
+        model.cross_reference()
+
+        # Assert all CIDs in MATCID
+        for cid in cids:
+            self.assertIn(cid, model.MATCID)
+
+        # Assert 4 CIDs in MATCID
+        self.assertEqual(len(list(model.MATCID.keys())), 4)
+
+        # Assert elements in MATCIDs
+        for cid, matcids in model.MATCID.items():
+            self.assertEqual(len(matcids), 1)
+            matcid = matcids[0]
+            self.assertEqual(matcid.Cid(), cid)
+
+            self.assertIn(matcid.form, [1, 2, 3, 4])
+
+            if matcid.form == 1:
+                self.assertEqual(matcid.Cid(), 7)
+                self.assertTrue((matcid.eids == np.array([7, 8, 9, 10, 11, 12, 13, 14], dtype=int)).all())
+                self.assertIsNone(matcid.start)
+                self.assertIsNone(matcid.thru)
+                self.assertIsNone(matcid.by)
+
+            elif matcid.form == 2:
+                self.assertEqual(matcid.Cid(), 8)
+                self.assertEqual(matcid.start, 7)
+                self.assertEqual(matcid.thru, 14)
+
+                self.assertIsNone(matcid.eids)
+                self.assertIsNone(matcid.by)
+
+            elif matcid.form == 3:
+                self.assertEqual(matcid.Cid(), 9)
+                self.assertEqual(matcid.start, 7)
+                self.assertEqual(matcid.thru, 14)
+                self.assertEqual(matcid.by, 1)
+
+                self.assertIsNone(matcid.eids)
+
+            else:  # matcid == 4
+                self.assertEqual(matcid.Cid(), 10)
+
+                self.assertIsNone(matcid.eids)
+                self.assertIsNone(matcid.start)
+                self.assertIsNone(matcid.thru)
+                self.assertIsNone(matcid.by)
+
         
 def make_tri(model):
     model.add_grid(1, [0., 0., 0.])


### PR DESCRIPTION
Added reading / writing of MATCID cards to the BDF.

Multiple cards can share the same CID. Therefore, I tried to use the same approach as for load cards (e.g., PLOAD4), i.e., the MATCID cards are stored as a dict whose keys are the unique CIDs and whose values are lists containing the MATCID cards referencing that CID:

 {cid1: List[matcid1, matcid2, ...], cid2: List[matcidN1, matcidN2, ...], ...}

I also tried to add a small unit test to check that the cards are correctly read and stored. 