### PR TITLE
Update add_card.py to fix error where X is being written as integer i…

### DIFF
--- a/pyNastran/bdf/bdf_interface/add_card.py
+++ b/pyNastran/bdf/bdf_interface/add_card.py
@@ -1440,7 +1440,7 @@ class Add0dElements:
         return prop
 
     def add_cgap(self, eid: int, pid: int, nids: list[int],
-                 x: Optional[list[int]], g0: Optional[int],
+                 x: Optional[list[float]], g0: Optional[int],
                  cid: Optional[int]=None, comment: str='') -> CGAP:
         """
         Creates a CGAP card


### PR DESCRIPTION
x must be changed from list of int to list of float, otherwise nastran assumes this is the GO field not the X1, X2, X3.