### PR TITLE
Support cweld and pweld card for MSC Nastran

### DIFF
--- a/pyNastran/bdf/__init__.py
+++ b/pyNastran/bdf/__init__.py
@@ -53,7 +53,7 @@ BULK_DATA_CARDS = {
     'CBUSH', 'CBUSH1D', 'CBUSH2D',
     # dampers
     'CDAMP1', 'CDAMP2', 'CDAMP3', 'CDAMP4', 'CDAMP5',
-    'CFAST',
+    'CFAST', 'CWELD',
 
     'CBAR', 'CBARAO', 'BAROR',
     'CROD', 'CTUBE', 'CBEAM', 'CBEAM3', 'CONROD', 'CBEND', 'BEAMOR',
@@ -78,7 +78,7 @@ BULK_DATA_CARDS = {
 
     ## properties
     'PMASS',
-    'PELAS', 'PGAP', 'PFAST', 'PLPLANE', 'PPLANE',
+    'PELAS', 'PGAP', 'PFAST', 'PWELD', 'PLPLANE', 'PPLANE',
     'PBUSH', 'PBUSH1D',
     'PDAMP', 'PDAMP5',
     'PROD', 'PBAR', 'PBARL', 'PBEAM', 'PTUBE', 'PBCOMP', 'PBRSECT', 'PBEND',
@@ -312,7 +312,7 @@ BULK_DATA_CARDS = {
 
     ## ???
     'ACMODL', 'PANEL', 'SWLDPRM',
-    'CWELD', 'PWELD', 'PWSEAM', 'CWSEAM', 'CSEAM', 'PSEAM', 'DVSHAP', 'BNDGRID',
+    'PWSEAM', 'CWSEAM', 'CSEAM', 'PSEAM', 'DVSHAP', 'BNDGRID',
     'MODTRAK', 'DSCONS', 'DVAR', 'DVSET', 'DYNRED',
     'BNDFIX', 'BNDFIX1',
     'AEFORCE', 'UXVEC', 'GUST2',

--- a/pyNastran/bdf/bdf.py
+++ b/pyNastran/bdf/bdf.py
@@ -217,7 +217,7 @@ SolidElement = CTETRA4 | CTETRA10 | CPENTA6 | CPENTA15 | \
 
 Element = (
     SpringElement | DamperElement |
-    CVISC | CBUSH | CBUSH1D | CBUSH2D | CFAST | CWELD
+    CVISC | CBUSH | CBUSH1D | CBUSH2D | CFAST | CWELD |
     CGAP | GENEL | CCONEAX |
     CROD | CTUBE | CONROD |
     CBAR | CBEAM | CBEAM3 | CBEND | CSHEAR |
@@ -402,7 +402,6 @@ MISSING_CARDS = {
     'CSPOT', 'CFILLET',
     'CBUTT',
     'PCOHE',
-    'CWELD', 'PWELD',
 
     ## rigid_elements
     'RSPINT', 'RSPINR', 'RBE2GS',
@@ -696,7 +695,7 @@ class BDF_(BDFMethods, GetCard, AddCards, WriteMeshs, UnXrefMesh):
 
             ## properties
             'PMASS',
-            'PELAS', 'PGAP', 'PFAST', 'PLPLANE', 'PPLANE',
+            'PELAS', 'PGAP', 'PFAST', 'PWELD', 'PLPLANE', 'PPLANE',
             'PBUSH', 'PBUSH1D', 'PBUSH2D',
             'PDAMP', 'PDAMP5',
             'PROD', 'PBAR', 'PBARL', 'PBEAM', 'PTUBE', 'PBCOMP', 'PBRSECT', 'PBEND',
@@ -948,7 +947,6 @@ class BDF_(BDFMethods, GetCard, AddCards, WriteMeshs, UnXrefMesh):
             'CONVM',
             ## ???
             #'PANEL', 'SWLDPRM',
-            #'CWELD', 'PWELD',
             # 'PWSEAM', 'CWSEAM', 'CSEAM', 'PSEAM', 'DVSHAP',
             #'CYSYM', 'CYJOIN', 'MODTRAK', 'DSCONS', 'DVAR', 'DVSET', 'DYNRED',
             #'AEFORCE', 'UXVEC', 'GUST2',
@@ -2214,9 +2212,6 @@ class BDF_(BDFMethods, GetCard, AddCards, WriteMeshs, UnXrefMesh):
             'ROTORB' : (Crash, None),
 
             #'SWLDPRM' : (Crash, None),
-
-            #'CWELD' : (Crash, None),
-            #'PWELD' : (Crash, None),
             #'PWSEAM' : (Crash, None),
             #'CWSEAM' : (Crash, None),
             #'CSEAM' : (Crash, None),

--- a/pyNastran/bdf/bdf.py
+++ b/pyNastran/bdf/bdf.py
@@ -53,9 +53,9 @@ from .bdf_interface.assign_type import (
 
 from pyNastran.bdf.bdf_interface.model_group import ModelGroup
 from .cards.elements.elements import (
-    CFAST, CGAP, CRAC2D, CRAC3D, GENEL,
+    CFAST, CWELD, CGAP, CRAC2D, CRAC3D, GENEL,
     PLOTEL, PLOTEL3, PLOTEL4, PLOTELs)
-from .cards.properties.properties import PFAST, PGAP, PRAC2D, PRAC3D
+from .cards.properties.properties import PFAST, PWELD, PGAP, PRAC2D, PRAC3D
 from .cards.properties.solid import PLSOLID, PSOLID, PIHEX, PCOMPS, PCOMPLS
 from .cards.cyclic import CYAX, CYJOIN
 from .cards.msgmesh import CGEN
@@ -217,7 +217,7 @@ SolidElement = CTETRA4 | CTETRA10 | CPENTA6 | CPENTA15 | \
 
 Element = (
     SpringElement | DamperElement |
-    CVISC | CBUSH | CBUSH1D | CBUSH2D | CFAST | #CWELD
+    CVISC | CBUSH | CBUSH1D | CBUSH2D | CFAST | CWELD
     CGAP | GENEL | CCONEAX |
     CROD | CTUBE | CONROD |
     CBAR | CBEAM | CBEAM3 | CBEND | CSHEAR |
@@ -245,7 +245,7 @@ Property = (
     PSHEAR | PPLANE |
     PSHELL | PCOMP | PCOMPG |
     PSOLID | PLSOLID | PIHEX | PCOMPS | PCOMPLS |
-    PTRSHL #| PWELD
+    PTRSHL | PWELD
 )
 Material = (
         MAT1 | MAT2 | MAT3 | MAT8 | MAT9 | MAT10 | MAT11 |
@@ -664,7 +664,8 @@ class BDF_(BDFMethods, GetCard, AddCards, WriteMeshs, UnXrefMesh):
             'CBUSH', 'CBUSH1D', 'CBUSH2D',
             # dampers
             'CDAMP1', 'CDAMP2', 'CDAMP3', 'CDAMP4', 'CDAMP5',
-            'CFAST',
+            # fasteners
+            'CFAST', 'CWELD',
 
             'CBAR', 'CBARAO', 'BAROR',
             'CROD', 'CTUBE', 'CBEAM', 'CBEAM3', 'CONROD', 'CBEND', 'BEAMOR',
@@ -2361,6 +2362,9 @@ class BDF_(BDFMethods, GetCard, AddCards, WriteMeshs, UnXrefMesh):
 
             'CFAST' : (CFAST, add_methods._add_damper_object),
             'PFAST' : (PFAST, add_methods._add_property_object),
+
+            'CWELD' : (CWELD, add_methods._add_damper_object),
+            'PWELD' : (PWELD, add_methods._add_property_object),
 
             'CGAP' : (CGAP, add_methods._add_element_object),
             'PGAP' : (PGAP, add_methods._add_property_object),

--- a/pyNastran/bdf/bdf_interface/add_card.py
+++ b/pyNastran/bdf/bdf_interface/add_card.py
@@ -1569,21 +1569,21 @@ class Add0dElements:
         self._add_methods._add_property_object(prop)
         return prop
 
-    def add_cweld(self, eid: int, pid: int, gs: int, elemid:str, ga:int, gb:int, mcid:int, shida: int, shidb: int, comment: str='') -> CWELD:
+    def add_cweld(self, eid: int, pid: int, gs: int, elemid:str, ga:int, gb:int, mcid:int, shida: int, shidb: int, x: list[float]=None, comment: str='') -> CWELD:
         """
         Creates a CWELD card
 
         """
-        elem = CWELD(eid, pid, gs, elemid, ga, gb, mcid, shida, shidb, comment=comment)
+        elem = CWELD(eid, pid, gs, elemid, ga, gb, mcid, shida, shidb, x, comment=comment)
         self._add_methods._add_element_object(elem)
         return elem
     
-    def add_pweld(self, pid: int, mid: int, d: float, mset: str, type:str, ldmin: float, ldmax: float, comment: str='') -> PWELD:
+    def add_pweld(self, pid: int, mid: int, d: float, mset: str=None, connect_type:str=None, ldmin: float=None, ldmax: float=None, comment: str='') -> PWELD:
         """
         Creates a PWELD card
 
         """
-        prop = PWELD(pid, mid, mid, d, mset, type, ldmin, ldmax, comment=comment)
+        prop = PWELD(pid, mid, mid, d, mset, connect_type, ldmin, ldmax, comment=comment)
         self._add_methods._add_property_object(prop)
         return prop
 

--- a/pyNastran/bdf/bdf_interface/add_card.py
+++ b/pyNastran/bdf/bdf_interface/add_card.py
@@ -17,8 +17,8 @@ from pyNastran.bdf.bdf_interface.add_methods import AddMethods
 
 from pyNastran.bdf.cards.bolt import BOLT, BOLTSEQ, BOLTFOR, BOLTLD, BOLTFRC
 from pyNastran.bdf.cards.elements.elements import (
-    CFAST, CGAP, CRAC2D, CRAC3D, PLOTEL, PLOTEL3, PLOTEL4, GENEL)
-from pyNastran.bdf.cards.properties.properties import PFAST, PGAP, PRAC2D, PRAC3D
+    CFAST, CWELD, CGAP, CRAC2D, CRAC3D, PLOTEL, PLOTEL3, PLOTEL4, GENEL)
+from pyNastran.bdf.cards.properties.properties import PFAST, PWELD, PGAP, PRAC2D, PRAC3D
 from pyNastran.bdf.cards.properties.solid import PLSOLID, PSOLID, PIHEX, PCOMPS, PCOMPLS
 from pyNastran.bdf.cards.cyclic import CYAX, CYJOIN
 #from pyNastran.bdf.cards.msgmesh import CGEN, GMCORD, GMLOAD
@@ -374,6 +374,9 @@ CARD_MAP = {
 
     'CFAST' : CFAST,
     'PFAST' : PFAST,
+
+    'CWELD' : CWELD,
+    'PWELD' : PWELD,
 
     'CGAP' : CGAP,
     'PGAP' : PGAP,
@@ -1566,6 +1569,23 @@ class Add0dElements:
         self._add_methods._add_property_object(prop)
         return prop
 
+    def add_cweld(self, eid: int, pid: int, gs: int, elemid:str, ga:int, gb:int, mcid:int, shida: int, shidb: int, comment: str='') -> CWELD:
+        """
+        Creates a CWELD card
+
+        """
+        elem = CWELD(eid, pid, gs, elemid, ga, gb, mcid, shida, shidb, comment=comment)
+        self._add_methods._add_element_object(elem)
+        return elem
+    
+    def add_pweld(self, pid: int, mid: int, d: float, mset: str, type:str, ldmin: float, ldmax: float, comment: str='') -> PWELD:
+        """
+        Creates a PWELD card
+
+        """
+        prop = PWELD(pid, mid, mid, d, mset, type, ldmin, ldmax, comment=comment)
+        self._add_methods._add_property_object(prop)
+        return prop
 
 class Add1dElements:
     def add_conrod(self, eid: int, mid: int, nids: list[int],

--- a/pyNastran/bdf/bdf_interface/add_methods.py
+++ b/pyNastran/bdf/bdf_interface/add_methods.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:  # pragma: no cover
         CAEROs, PAEROs, SPLINEs, FREQs,
     )
     from pyNastran.bdf.cards.bolt import BOLT, BOLTFOR, BOLTSEQ, BOLTLD
-    from pyNastran.bdf.cards.elements.elements import CFAST, CGAP, CRAC2D, CRAC3D, PLOTELs, GENEL
+    from pyNastran.bdf.cards.elements.elements import CFAST, CWELD, CGAP, CRAC2D, CRAC3D, PLOTELs, GENEL
     #from pyNastran.bdf.cards.properties.properties import PFAST, PGAP, PRAC2D, PRAC3D
     #from pyNastran.bdf.cards.properties.solid import PLSOLID, PSOLID, PIHEX, PCOMPS, PCOMPLS
     #from pyNastran.bdf.cards.msgmesh import CGEN, GMCORD

--- a/pyNastran/bdf/bdf_interface/attributes.py
+++ b/pyNastran/bdf/bdf_interface/attributes.py
@@ -850,7 +850,7 @@ class BDFAttributes:
                 'CBUSH', 'CBUSH1D', 'CBUSH2D',
 
                 'CDAMP1', 'CDAMP2', 'CDAMP3', 'CDAMP4', 'CDAMP5',
-                'CFAST', 'GENEL',
+                'CFAST', 'CWELD','GENEL',
 
                 'CBAR', 'CROD', 'CTUBE', 'CBEAM', 'CBEAM3', 'CONROD', 'CBEND',
                 'CTRIA3', 'CTRIA6', 'CTRIAR',
@@ -884,7 +884,7 @@ class BDFAttributes:
                 'PACABS', 'PAABSF', 'PACBAR', 'PMIC',
 
                 # 0d
-                'PELAS', 'PGAP', 'PFAST',
+                'PELAS', 'PGAP', 'PFAST', 'PWELD',
                 'PBUSH', 'PBUSH1D', 'PBUSH2D',
                 'PDAMP', 'PDAMP5',
 

--- a/pyNastran/bdf/bdf_interface/card_groups.py
+++ b/pyNastran/bdf/bdf_interface/card_groups.py
@@ -78,7 +78,8 @@ structure = {
     'CBUSH', 'CBUSH1D', 'CBUSH2D',
     # dampers
     'CDAMP1', 'CDAMP2', 'CDAMP3', 'CDAMP4', 'CDAMP5',
-    'CFAST',
+    # fasteners
+    'CFAST', 'CWELD',
 
     'CBAR', 'CBARAO', 'BAROR',
     'CROD', 'CTUBE', 'CBEAM', 'CBEAM3', 'CONROD', 'CBEND', 'BEAMOR',
@@ -94,7 +95,7 @@ structure = {
 
     ## properties
     'PMASS',
-    'PELAS', 'PGAP', 'PFAST', 'PLPLANE', 'PPLANE',
+    'PELAS', 'PGAP', 'PFAST', 'PWELD', 'PLPLANE', 'PPLANE',
     'PBUSH', 'PBUSH1D',
     'PDAMP', 'PDAMP5',
     'PROD', 'PBAR', 'PBARL', 'PBEAM', 'PTUBE', 'PBCOMP', 'PBRSECT', 'PBEND',

--- a/pyNastran/bdf/bdf_interface/stats.py
+++ b/pyNastran/bdf/bdf_interface/stats.py
@@ -314,6 +314,7 @@ def get_bdf_stats(model: BDF, return_type: str='string',
 
         group_msg = []
         ncards_total = 0
+        print(groups)
         for card_name in sorted(groups):
             try:
                 ncards = model.card_count[card_name]

--- a/pyNastran/bdf/bdf_interface/stats.py
+++ b/pyNastran/bdf/bdf_interface/stats.py
@@ -314,7 +314,6 @@ def get_bdf_stats(model: BDF, return_type: str='string',
 
         group_msg = []
         ncards_total = 0
-        print(groups)
         for card_name in sorted(groups):
             try:
                 ncards = model.card_count[card_name]

--- a/pyNastran/bdf/cards/elements/elements.py
+++ b/pyNastran/bdf/cards/elements/elements.py
@@ -391,10 +391,9 @@ class CWELD(CFAST):
     def Gs(self):
         """Gets the GS node"""
         if self.gs is not None:
-            if isinstance(self.gs, integer_types):
-                return self.gs
-            else:
-                return self.gs_ref.nid
+            return self.gs_ref.nid
+        elif isinstance(self.gs, integer_types):
+            return self.gs
         else:
             if self.ga is None:
                 # If neither GS nor GA is specified, then (XS, YS, ZS) in basic must be specified.

--- a/pyNastran/bdf/cards/elements/elements.py
+++ b/pyNastran/bdf/cards/elements/elements.py
@@ -237,6 +237,157 @@ class CFAST(Element):
         return self.comment + print_card_8(card)
 
 
+class CWELD(CFAST):
+    """
+    There are five different formats of the CWELD card as GRIDid, ELEMID, ELPAT and PARTPAT.
+    ELEMID format:
+    +-------+-----+-----+-----+--------+-----+-----+-----+-----+
+    |   1   |  2  |  3  |  4  |  5     |  6  |  7  |  8  |  9  |
+    +=======+=====+=====+=====+========+=====+=====+=====+=====+
+    | CWELD | EWID| PWID| GS  |"ELEMID"| GA  | GB  |     | MCID|
+    +-------+-----+-----+-----+--------+-----+-----+-----+-----+
+    |       |SHIDA|SHIDB|     |        |     |     |     |     |
+    +-------+-----+-----+-----+--------+-----+-----+-----+-----+
+    or PARTPAT format:
+    +-------+-----+-----+-----+---------+-----+-----+-----+-----+
+    |   1   |  2  |  3  |  4  |  5      |  6  |  7  |  8  |  9  |
+    +=======+=====+=====+=====+========+=====+=====+======+=====+
+    | CWELD | EWID| PWID| GS  |"PARTPAT"| GA  | GB |      |MCID |
+    +-------+-----+-----+-----+---------+-----+----+------+-----+
+    |  PIDA | PIDB|     |     |         |     |    |      |     |
+    +-------+-----+-----+-----+---------+-----+----+------+-----+
+    |  XS   | YS  | ZS  |     |         |     |    |      |     |
+    +-------+-----+-----+-----+---------+-----+----+------+-----+
+    or ELPAT:
+    +-------+-----+-----+-----+--------+-----+-----+-----+-----+
+    |   1   |  2  |  3  |  4  |  5     |  6  |  7  |  8  |  9  |
+    +=======+=====+=====+=====+========+=====+======+=====+=====+
+    | CWELD | EWID| PWID| GS  |"ELPAT" | GA  | GB  |     | MCID|
+    +-------+-----+-----+-----+--------+-----+-----+-----+-----+
+    |       |SHIDA|SHIDB|     |        |     |     |     |     |
+    +-------+-----+-----+-----+--------+-----+-----+-----+-----+
+    |       | XS  |   YS|  ZS |        |     |     |     |     |
+    +-------+-----+-----+-----+--------+-----+-----+-----+-----+
+    "ELEMID" string indicating that the connectivity of surface patch A to surface patch B is defined with two shell element identification numbers, SHIDA and SHIDB, respectively.
+    """
+    type = 'CWELD'
+    _properties = ['node_ids', 'nodes']
+    _field_map = {
+        1: 'eid', 2:'pid', 3:'gs', 4:'connectype', 5:'ga', 6:'gb', 8:'mcid',
+    }
+    cp_name_map = {
+        }
+
+    @classmethod
+    def _init_from_empty(cls):
+        eid = 1
+        pid = 1
+        connectype = 'ELEMID'
+        return CWELD(eid, pid, gs=None, connectype=connectype, ga=None, gb=None, mcid=None, shida=None, shidb=None, comment='')
+    
+    def __init__(self, eid: int, pid: int, gs: Optional[int], connectype: str, ga: int, gb: int, mcid=None, shida:Optional[int]=None, shidb:Optional[int]=None, pida:Optional[int]=None, pidb:Optional[int]=None, x:Optional[list[float]]=None, comment:str=''):
+        Element.__init__(self)
+        if comment:
+            self.comment = comment
+        if pid is None:
+            pid = eid
+        self.eid = eid
+        self.pid = pid
+        self.gs = gs
+        self.connectype = connectype
+        self.ga = ga
+        self.gb = gb
+        self.mcid = mcid
+        self.pida = pida
+        self.pidb = pidb
+        self.x = x
+        self.shida = shida
+        self.shidb = shidb
+        self.pid_ref = None
+        self.gs_ref = None
+        self.ga_ref = None
+        self.gb_ref = None
+
+    def validate(self):
+        if self.connectype in ['GRIDID', 'ALIGN']:
+            msg = f'Format "GRIDID" or "ALIGN" of CWELD of element eid={self.eid} is not supported'
+            raise TypeError(msg)
+        
+        if self.gs is None and self.ga is None:
+            msg = f'The definition of CWELD; eid={self.eid} is not correct, either GS or GA must be defined'
+            raise ValueError(msg)
+        
+    @classmethod
+    def add_card(cls, card, comment=''):
+        """
+        Adds a CWELD card from ``BDF.add_card(...)``
+
+        Parameters
+        ----------
+        card : BDFCard()
+            a BDFCard object
+        comment : str; default=''
+            a comment for the card
+
+        """
+        eid = integer(card, 1, 'eid')
+        pid = integer_or_blank(card, 2, 'pid', eid)
+        gs = integer_or_blank(card, 3, 'gs')
+        connectype = string(card, 4, 'connectype')
+        
+        ga = integer(card, 5, 'ga')
+        gb = integer(card, 6, 'gb')
+        mcid = integer_or_blank(card, 8,'mcid')
+        shida = integer_or_blank(card, 9,'shida')
+        shidb = integer_or_blank(card, 10,'shidb')
+        assert len(card)<=11, f'len(CWELD card) = {len(card):d}\ncard={card}'
+
+        return CWELD(eid, pid, gs, connectype, ga, gb, mcid=mcid, shida=shida, shidb=shidb, comment=comment)
+    
+    def cross_reference(self, model: BDF) -> None:
+        """
+        Cross links the card so referenced cards can be extracted directly"
+        
+        Parameters
+        ----------
+        model : BDF()
+            the BDF object
+        """
+        msg = ', which is required by CWELD eid=%s' % self.eid
+        self.pid_ref = model.Property(self.Pid(), msg=msg)
+        if self.gs:
+            self.gs_ref = model.Node(self.Gs(), msg=msg)
+        if self.ga:
+            self.ga_ref = model.Node(self.Ga(), msg=msg)
+        if self.gb:
+            self.gb_ref = model.Node(self.Gb(), msg=msg)
+
+    def raw_fields(self):
+        gs = self._get_gs()
+        list_fields = ['CWELD', self.eid, self.Pid(), gs, self.elemid,  self.Ga(), self.Gb(), self.mcid, self.shida, self.shidb]
+        return list_fields
+    
+    def Gs(self):
+        """Gets the GS node"""
+        if isinstance(self.gs, integer_types):
+            return self.gs
+        elif self.gs is not None:
+            return self.gs_ref.nid
+        elif self.gs is None:
+            if self.ga is None:
+                # If neither GS nor GA is specified, then (XS, YS, ZS) in basic must be specified.
+                raise RuntimeError(f'Neither Gs nor GA was not returned from CWELD\n{self.get_stats()}')
+            else:
+                return self.ga_ref.nid
+
+    def _get_gs(self) -> Optional[int]:
+        if self.gs is None:
+            out = (self.gs)
+        else:
+            out = (self.Gs())
+        return out
+    
+
 class CGAP(Element):
     """
     +------+-----+-----+-----+-----+-----+-----+------+-----+

--- a/pyNastran/bdf/cards/elements/elements.py
+++ b/pyNastran/bdf/cards/elements/elements.py
@@ -390,7 +390,7 @@ class CWELD(CFAST):
     
     def Gs(self):
         """Gets the GS node"""
-        if self.gs is not None:
+        if self.gs_ref is not None:
             return self.gs_ref.nid
         elif isinstance(self.gs, integer_types):
             return self.gs

--- a/pyNastran/bdf/cards/elements/elements.py
+++ b/pyNastran/bdf/cards/elements/elements.py
@@ -343,19 +343,19 @@ class CWELD(CFAST):
         if connectype == 'ELEMID':
             x = [None, None, None]
             assert len(card)<=11, f'len(CWELD card) = {len(card):d}\ncard={card}'
-            return CWELD(eid, pid, gs, connectype, ga, gb, mcid=mcid, shida=shida_pida, shidb=shidb_pidb, comment=comment)
         elif connectype == 'ELPAT':
             x = [double_or_blank(card, 18, 'xs', 0.0),
                  double_or_blank(card, 19, 'ys', 0.0),
                  double_or_blank(card, 20, 'zs', 0.0)]
             assert len(card)<=21, f'len(CWELD card) = {len(card):d}\ncard={card}'
-            return CWELD(eid, pid, gs, connectype, ga, gb, mcid=mcid, shida=shida_pida, shidb=shidb_pidb, x=x, comment=comment)
         elif connectype == 'PARTPAT':
             x = [double_or_blank(card, 18, 'xs', 0.0),
                  double_or_blank(card, 19, 'ys', 0.0),
                  double_or_blank(card, 20, 'zs', 0.0)]
             assert len(card)<=21, f'len(CWELD card) = {len(card):d}\ncard={card}'
-            return CWELD(eid, pid, gs, connectype, ga, gb, mcid=mcid, shida=shida_pida, shidb=shida_pida, x=x, comment=comment)
+        else:
+            raise NameError(f'connectype={connectype!r} is not supported')
+        return CWELD(eid, pid, gs, connectype, ga, gb, mcid=mcid, shida=shida_pida, shidb=shidb_pidb, x=x, comment=comment)
    
     def cross_reference(self, model: BDF) -> None:
         """
@@ -377,22 +377,25 @@ class CWELD(CFAST):
 
     def raw_fields(self):
         if self.connectype == 'ELEMID':
-            list_fields = ['CWELD', self.eid, self.Pid(), gs, self.connectype,  self.Ga(), self.Gb(), self.mcid, self.shida, self.shidb]
+            list_fields = ['CWELD', self.eid, self.Pid(), self.gs, self.connectype, self.Ga(), self.Gb(), self.mcid, self.shida, self.shidb]
         elif self.connectype == 'ELPAT':
             xs, ys, zs = self.x
-            list_fields = ['CWELD', self.eid, self.Pid(), gs, self.connectype,  self.Ga(), self.Gb(), self.mcid, self.shida, self.shidb, xs, ys, zs]
+            list_fields = ['CWELD', self.eid, self.Pid(), self.gs, self.connectype, self.Ga(), self.Gb(), self.mcid, self.shida, self.shidb, xs, ys, zs]
         elif self.connectype == 'PARTPAT':
             xs, ys, zs = self.x
-            list_fields = ['CWELD', self.eid, self.Pid(), gs, self.connectype,  self.Ga(), self.Gb(), self.mcid, self.pida, self.pidb, xs, ys, zs]
+            list_fields = ['CWELD', self.eid, self.Pid(), self.gs, self.connectype, self.Ga(), self.Gb(), self.mcid, self.pida, self.pidb, xs, ys, zs]
+        else:
+            raise NameError(f'connectype={self.connectype!r} is not supported')
         return list_fields
     
     def Gs(self):
         """Gets the GS node"""
-        if isinstance(self.gs, integer_types):
-            return self.gs
-        elif self.gs is not None:
-            return self.gs_ref.nid
-        elif self.gs is None:
+        if self.gs is not None:
+            if isinstance(self.gs, integer_types):
+                return self.gs
+            else:
+                return self.gs_ref.nid
+        else:
             if self.ga is None:
                 # If neither GS nor GA is specified, then (XS, YS, ZS) in basic must be specified.
                 raise RuntimeError(f'Neither Gs nor GA was not returned from CWELD\n{self.get_stats()}')

--- a/pyNastran/bdf/cards/properties/properties.py
+++ b/pyNastran/bdf/cards/properties/properties.py
@@ -259,7 +259,7 @@ class PWELD(Property):
     """
     type = 'PWELD'
     _field_map = {
-        1: 'pid', 2:'mid', 3:'d', 6:'mset', 8:'type', 9:'ldmin', 10:'ldmax',
+        1: 'pid', 2:'mid', 3:'d', 6:'mset', 8:'connect_type', 9:'ldmin', 10:'ldmax',
     }
     pname_fid_map = {
         'MID' :'mid',
@@ -272,7 +272,7 @@ class PWELD(Property):
         pid = 1
         mid = 2
         d = 0.1
-        return PWELD(pid, mid, d, mset=None, type=None, ldmin=None, ldmax=None, comment='')
+        return PWELD(pid, mid, d, mset=None, connect_type=None, ldmin=None, ldmax=None, comment='')
     
     def __init__(self, pid: int, mid: int, d: float, mset:str=None, connect_type: str=None, ldmin:float=None, ldmax:float=None, comment: str='') -> PWELD:
         """

--- a/pyNastran/bdf/cards/properties/properties.py
+++ b/pyNastran/bdf/cards/properties/properties.py
@@ -259,7 +259,7 @@ class PWELD(Property):
     """
     type = 'PWELD'
     _field_map = {
-        1: 'pid', 2:'mid', 3:'d', 6:'mset', 9:'ldmin', 10:'ldmax',
+        1: 'pid', 2:'mid', 3:'d', 6:'mset', 8:'type', 9:'ldmin', 10:'ldmax',
     }
     pname_fid_map = {
         'MID' :'mid',
@@ -272,9 +272,9 @@ class PWELD(Property):
         pid = 1
         mid = 2
         d = 0.1
-        return PWELD(pid, mid, d, mset=None, ldmin=None, ldmax=None, comment='')
+        return PWELD(pid, mid, d, mset=None, type=None, ldmin=None, ldmax=None, comment='')
     
-    def __init__(self, pid: int, mid: int, d: float, mset:str=None, ldmin:float=None, ldmax:float=None, comment: str='') -> PWELD:
+    def __init__(self, pid: int, mid: int, d: float, mset:str=None, connect_type: str=None, ldmin:float=None, ldmax:float=None, comment: str='') -> PWELD:
         """
         Creates a PWELD card
         Parameters
@@ -306,6 +306,8 @@ class PWELD(Property):
         self.d = d
         #: M-set flag
         self.mset = mset
+        #: Type of weld
+        self.connect_type = connect_type
         #: Minimum length of the weld
         self.ldmin = ldmin
         #: Maximum length of the weld
@@ -326,10 +328,11 @@ class PWELD(Property):
         mid = integer(card, 2,'mid')
         d = double(card, 3, 'd')
         mset = string_or_blank(card, 6,'mset', 'OFF')
+        connect_type = string_or_blank(card, 8, 'connect_type')
         ldmin = double_or_blank(card, 9, 'ldmin')
         ldmax = double_or_blank(card, 10, 'ldmax')
         assert len(card) <= 11, f'len(PWELD card) = {len(card):d}\ncard={card}'
-        return PWELD(pid, mid, d, mset=mset, ldmin=ldmin, ldmax=ldmax, comment=comment)
+        return PWELD(pid, mid, d, mset=mset, connect_type=connect_type, ldmin=ldmin, ldmax=ldmax, comment=comment)
     
     @classmethod
     def add_op2_data(cls, data, comment=''):
@@ -342,8 +345,8 @@ class PWELD(Property):
         comment : str; default=''
             a comment for the card
         """
-        (pid, mid, d, mset, ldmin, ldmax) = data
-        return PWELD(pid, mid, d, mset=mset, ldmin=ldmin, ldmax=ldmax, comment=comment)
+        (pid, mid, d, mset, connect_type, ldmin, ldmax) = data
+        return PWELD(pid, mid, d, mset=mset, connect_type=connect_type, ldmin=ldmin, ldmax=ldmax, comment=comment)
     
     def cross_reference(self, model: BDF) -> None:
         """
@@ -365,12 +368,12 @@ class PWELD(Property):
 
     def raw_fields(self):
         fields = ['PWELD', self.pid, self.Mid(), self.d,
-                  self.mset, self.ldmin, self.ldmax]
+                  self.mset, self.connect_type, self.ldmin, self.ldmax]
         return fields
     
     def repr_fields(self):
         mset = set_blank_if_default(self.mset, 'OFF')
-        fields = ['PWELD', self.pid, self.Mid(), self.d, mset, self.ldmin, self.ldmax]
+        fields = ['PWELD', self.pid, self.Mid(), self.d, mset, self.connect_type, self.ldmin, self.ldmax]
         return fields
     
     def write_card(self, size: int=8, is_double: bool=False) -> str:


### PR DESCRIPTION
There exists five different formats of CWELD card in MSC Nastran. In this PR, three most common used formats are supported: PARTRAT, ELPAT, ELEMID.