### PR TITLE
Small improvement to error handling logic when there are duplicate cards

### DIFF
--- a/pyNastran/bdf/bdf.py
+++ b/pyNastran/bdf/bdf.py
@@ -1725,7 +1725,6 @@ class BDF_(BDFMethods, GetCard, AddCards, WriteMeshs, UnXrefMesh):
                             msg += str(elem)
                     msg += '\n'
                     is_error = True
-                    raise DuplicateIDsError(msg)
 
             if self._duplicate_properties:
                 duplicate_pids = [prop.pid for prop in self._duplicate_properties]

--- a/pyNastran/bdf/bdf.py
+++ b/pyNastran/bdf/bdf.py
@@ -1797,7 +1797,7 @@ class BDF_(BDFMethods, GetCard, AddCards, WriteMeshs, UnXrefMesh):
             if self.xref_obj._stop_on_xref_error:
                 msg += 'There are parsing errors.\n\n'
                 for (card, an_error) in self._stored_parse_errors:
-                    msg += '%scard=%s\n' % (an_error[0], card)
+                    msg += 'card=%s\n' % card
                     msg += 'xref error: %s\n\n' % an_error[0]
                     is_error = True
 


### PR DESCRIPTION
This PR is makes two changes:

 - Removes an early call to `raise DuplicateIDsError(msg)` that was preventing other duplicate cards from being included in the exception message when there were duplicate elements (as opposed to coords, mats, etc).
 - Removes a duplicate print statement when parsing errors occur