### PR TITLE
Preserve order of CSUPER cards

### DIFF
--- a/pyNastran/bdf/cards/superelements.py
+++ b/pyNastran/bdf/cards/superelements.py
@@ -870,7 +870,7 @@ class CSUPER(BaseCard):
         self.seid = seid
         self.psid = psid
         #:  Identifiers of grids points. (Integer > 0)
-        self.nodes = expand_thru(nodes)
+        self.nodes = expand_thru(nodes, set_fields=False)
         self.nodes_ref = None
 
     @classmethod


### PR DESCRIPTION
This minor change preserves the ordering of nodes in `CSUPER` cards. Converting them to a `set` gets rid of the original ordering. 