### PR TITLE
fix(security): 2 improvements across 1 files

### DIFF
--- a/dev/remove_test_files.py
+++ b/dev/remove_test_files.py
@@ -32,7 +32,7 @@ def main():
     for folder0 in folders:
         folder = os.path.abspath(os.path.join(BASE, folder0))
         if os.path.commonpath([BASE, folder]) != BASE:
-            print(f'*failed to delete folder: {folder0}')
+            print(f'*skipped folder due to incorrect path: {folder0}')
         elif os.path.exists(folder) and delete:
             print(f'deleting folder: {folder0}')
             shutil.rmtree(folder)
@@ -43,7 +43,7 @@ def main():
     for fname0 in files:
         fname = os.path.abspath(os.path.join(BASE, fname0))
         if os.path.commonpath([BASE, fname]) != BASE:
-            print(f'*failed to delete file: {fname0}')
+            print(f'*skipped file due to incorrect path: {fname0}')
         elif os.path.exists(fname) and delete:
             print(f'deleting file: {fname0}')
             os.remove(fname)

--- a/dev/remove_test_files.py
+++ b/dev/remove_test_files.py
@@ -16,9 +16,11 @@ def main():
     files_folders = [line.rstrip() for line in lines if line.rstrip()]
     for folder_fname0 in files_folders:
         if os.path.isabs(folder_fname0):
+            print(f'*skipped absolute path: {folder_fname0}')
             continue
         folder_fname = os.path.abspath(os.path.join(BASE, folder_fname0))
         if os.path.commonpath([BASE, folder_fname]) != BASE:
+            print(f'*skipped path outside base: {folder_fname0}')
             continue
         if not os.path.exists(folder_fname):
             print(f'*skipped missing path: {folder_fname0}')

--- a/dev/remove_test_files.py
+++ b/dev/remove_test_files.py
@@ -42,7 +42,7 @@ def main():
             print(f'deleting folder: {folder0}')
             shutil.rmtree(folder)
             if os.path.exists(folder):
-                print(f'*skipped folder due to incorrect path: {folder0}')
+                print(f'*failed to delete folder: {folder0}')
         elif os.path.exists(folder):
             print(f'dry run folder: {folder0}')
         else:
@@ -55,7 +55,7 @@ def main():
             print(f'deleting file: {fname0}')
             os.remove(fname)
             if os.path.exists(fname):
-                print(f'*skipped file due to incorrect path: {fname0}')
+                print(f'*failed to delete file: {fname0}')
         elif os.path.exists(fname):
             print(f'dry run file: {fname0}')
         else:

--- a/dev/remove_test_files.py
+++ b/dev/remove_test_files.py
@@ -43,7 +43,7 @@ def main():
         elif os.path.exists(folder):
             print(f'dry run folder: {folder0}')
         else:
-            print(f'*failed to delete folder: {folder0}')
+            print(f'*skipped folder due to incorrect path: {folder0}')
     for fname0 in files:
         fname = os.path.abspath(os.path.join(BASE, fname0))
         if os.path.commonpath([BASE, fname]) != BASE:
@@ -56,7 +56,7 @@ def main():
         elif os.path.exists(fname):
             print(f'dry run file: {fname0}')
         else:
-            print(f'*failed to delete file: {fname0}')
+            print(f'*skipped file due to incorrect path: {fname0}')
     x = 1
 
 if __name__ == '__main__':

--- a/dev/remove_test_files.py
+++ b/dev/remove_test_files.py
@@ -36,6 +36,8 @@ def main():
         elif os.path.exists(folder) and delete:
             print(f'deleting folder: {folder0}')
             shutil.rmtree(folder)
+            if os.path.exists(folder):
+                print(f'*failed to delete folder: {folder0}')
         elif os.path.exists(folder):
             print(f'dry run folder: {folder0}')
         else:
@@ -47,6 +49,8 @@ def main():
         elif os.path.exists(fname) and delete:
             print(f'deleting file: {fname0}')
             os.remove(fname)
+            if os.path.exists(fname):
+                print(f'*failed to delete file: {fname0}')
         elif os.path.exists(fname):
             print(f'dry run file: {fname0}')
         else:

--- a/dev/remove_test_files.py
+++ b/dev/remove_test_files.py
@@ -29,6 +29,8 @@ def main():
             files.append(folder_fname0)
 
     delete = '--delete' in os.sys.argv
+    if not delete:
+        print('dry run mode; pass --delete to actually remove files/folders')
     for folder0 in folders:
         folder = os.path.abspath(os.path.join(BASE, folder0))
         if os.path.commonpath([BASE, folder]) != BASE:

--- a/dev/remove_test_files.py
+++ b/dev/remove_test_files.py
@@ -42,7 +42,7 @@ def main():
             print(f'deleting folder: {folder0}')
             shutil.rmtree(folder)
             if os.path.exists(folder):
-                print(f'*failed to delete folder: {folder0}')
+                print(f'*skipped folder due to incorrect path: {folder0}')
         elif os.path.exists(folder):
             print(f'dry run folder: {folder0}')
         else:
@@ -55,7 +55,7 @@ def main():
             print(f'deleting file: {fname0}')
             os.remove(fname)
             if os.path.exists(fname):
-                print(f'*failed to delete file: {fname0}')
+                print(f'*skipped file due to incorrect path: {fname0}')
         elif os.path.exists(fname):
             print(f'dry run file: {fname0}')
         else:

--- a/dev/remove_test_files.py
+++ b/dev/remove_test_files.py
@@ -34,6 +34,8 @@ def main():
     delete = '--delete' in os.sys.argv
     if not delete:
         print('dry run mode; pass --delete to actually remove files/folders')
+    else:
+        print('delete mode enabled; files/folders will be removed')
     for folder0 in folders:
         folder = os.path.abspath(os.path.join(BASE, folder0))
         if os.path.commonpath([BASE, folder]) != BASE:

--- a/dev/remove_test_files.py
+++ b/dev/remove_test_files.py
@@ -4,7 +4,7 @@ import pyNastran
 
 def main():
     PKG_PATH = pyNastran.__path__[0]
-    BASE = os.path.join(PKG_PATH, '..')
+    BASE = os.path.abspath(os.path.join(PKG_PATH, '..'))
     test_filename = os.path.join(BASE, 'dev', 'test_files.txt')
     assert os.path.exists(test_filename), test_filename
 
@@ -15,7 +15,11 @@ def main():
     folders = []
     files_folders = [line.rstrip() for line in lines if line.rstrip()]
     for folder_fname0 in files_folders:
+        if os.path.isabs(folder_fname0):
+            continue
         folder_fname = os.path.abspath(os.path.join(BASE, folder_fname0))
+        if os.path.commonpath([BASE, folder_fname]) != BASE:
+            continue
         if not os.path.exists(folder_fname):
             continue
         assert os.path.exists(folder_fname), folder_fname0
@@ -24,19 +28,27 @@ def main():
         else:
             files.append(folder_fname0)
 
-    delete = False
+    delete = '--delete' in os.sys.argv
     for folder0 in folders:
         folder = os.path.abspath(os.path.join(BASE, folder0))
-        if os.path.exists(folder) and not delete:
+        if os.path.commonpath([BASE, folder]) != BASE:
+            print(f'*failed to delete folder: {folder0}')
+        elif os.path.exists(folder) and delete:
             print(f'deleting folder: {folder0}')
             shutil.rmtree(folder)
+        elif os.path.exists(folder):
+            print(f'dry run folder: {folder0}')
         else:
             print(f'*failed to delete folder: {folder0}')
     for fname0 in files:
         fname = os.path.abspath(os.path.join(BASE, fname0))
-        if os.path.exists(fname) and not delete:
+        if os.path.commonpath([BASE, fname]) != BASE:
+            print(f'*failed to delete file: {fname0}')
+        elif os.path.exists(fname) and delete:
             print(f'deleting file: {fname0}')
             os.remove(fname)
+        elif os.path.exists(fname):
+            print(f'dry run file: {fname0}')
         else:
             print(f'*failed to delete file: {fname0}')
     x = 1

--- a/dev/remove_test_files.py
+++ b/dev/remove_test_files.py
@@ -21,6 +21,7 @@ def main():
         if os.path.commonpath([BASE, folder_fname]) != BASE:
             continue
         if not os.path.exists(folder_fname):
+            print(f'*skipped missing path: {folder_fname0}')
             continue
         assert os.path.exists(folder_fname), folder_fname0
         if os.path.isdir(folder_fname):


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 1 files

## Problem

**Severity**: `High` | **File**: `dev/remove_test_files.py:L16`

The cleanup utility reads paths from `dev/test_files.txt`, resolves them with `os.path.abspath(os.path.join(BASE, folder_fname0))`, and then deletes them with `shutil.rmtree` / `os.remove`. Because there is no boundary check that resolved paths stay under `BASE`, entries like `../../...` or absolute paths can target unintended locations and delete arbitrary files/directories when run.

## Solution

Enforce a safe root: after resolving, verify each path is within `BASE` using `os.path.commonpath([BASE, resolved]) == BASE` before deletion. Reject absolute paths from the manifest, and require explicit confirmation/dry-run mode before destructive operations.

## Changes

- `dev/remove_test_files.py` (modified)