### PR TITLE
Fix off-by-one when len(fields) is multiple of 8 in print_int_card

### DIFF
--- a/pyNastran/bdf/field_writer_8.py
+++ b/pyNastran/bdf/field_writer_8.py
@@ -348,11 +348,8 @@ def print_int_card(fields: list[Optional[int | float | str]]) -> str:
         raise
 
     nfields = len(fields)
-    i0 = 1
     if nfields > 8:
-        niter = nfields // 8
-        i0 += 8 * niter
-        for i in range(1, i0, 8):
+        for i in range(1, nfields - 7, 8):
             field1, field2, field3, field4, field5, field6, field7, field8 = fields[i:i+8]
             try:
                 # balks if you have None or string fields
@@ -362,6 +359,7 @@ def print_int_card(fields: list[Optional[int | float | str]]) -> str:
                 warnings.warn('bad fields = %s' % fields)
                 raise
 
+    i0 = 1 + 8 * ((nfields - 1) // 8)   # first remainder index
     for i in range(i0, nfields):
         field = fields[i]
         try:


### PR DESCRIPTION
Fix an off-by-one bug in print_int_card() where the number of 8-field numeric blocks was computed using len(fields)//8, incorrectly counting the card name (fields[0]) as part of the numeric block packing (print_int_card prints the card name separately and then prints numeric fields in 8-wide groups starting at index 1).

Example trigger: len(fields)=208 (including card name) --> 208 % 8 == 0 --> extra bulk iteration --> ValueError: not enough values to unpack failure in the original code.

(can't run all_tests_no_gui.py, I fail to find the module "notebook_to_markdown")