### PR TITLE
Reject free-field lines that exceed the 10-field line grammar

### DIFF
--- a/models/sol_101_elements/static_solid_shell_bar_global_radial_cd.bdf
+++ b/models/sol_101_elements/static_solid_shell_bar_global_radial_cd.bdf
@@ -66,5 +66,6 @@ SPC1     123456     456  5       thru    13
 $ Nodal Forces of Load Set : 10000
 FORCE    10000   13      0      10000.   0.      0.     1.
 $ Referenced Coordinate Frames
-CORD2C,1,0, 0.,0.,0., 0.,0.,1., 0.,1.,0.
+CORD2C,1,0,0.,0.,0.,0.,0.,1.
+,0.,1.,0.
 ENDDATA 58e050da

--- a/pyNastran/bdf/bdf_interface/test/test_utils.py
+++ b/pyNastran/bdf/bdf_interface/test/test_utils.py
@@ -1,6 +1,8 @@
 """Tests for pyNastran.bdf.bdf_interface.utils (to_fields, expand_tabs)."""
 import unittest
+from io import StringIO
 from pyNastran.bdf.bdf_interface.utils import to_fields, expand_tabs
+from pyNastran.bdf.bdf import read_bdf
 from pyNastran.bdf.errors import CardParseSyntaxError
 
 
@@ -245,6 +247,117 @@ class TestToFields(unittest.TestCase):
         line2 = '*        100'
         fields = to_fields([line1, line2], 'CARD')
         self.assertEqual(fields[8].strip(), '')
+
+    def test_csv_line0_overflow_raises(self):
+        """A free-field line-0 with more than 10 fields raises CardParseSyntaxError."""
+        line = 'GRID,1,,1.0,2.0,3.0,,,1,999,888'
+        with self.assertRaises(CardParseSyntaxError):
+            to_fields([line], 'GRID')
+
+    def test_csv_field10_data_raises(self):
+        """Data in field 10 (the continuation slot) raises CardParseSyntaxError."""
+        line = 'GRID,1,,1.0,2.0,3.0,,,1,999'
+        with self.assertRaises(CardParseSyntaxError):
+            to_fields([line], 'GRID')
+
+    def test_csv_field10_marker_ok(self):
+        """A continuation marker in field 10 is dropped, not an error."""
+        line = 'GRID,1,,1.0,2.0,3.0,,,1,+'
+        fields = to_fields([line], 'GRID')
+        self.assertEqual(len(fields), 9)
+        self.assertNotIn('+', fields)
+
+    def test_csv_field10_numeric_marker_ok(self):
+        """A numeric continuation marker like '+01' is allowed in field 10."""
+        line = 'TABLED1,100,,,,,,,,+01'
+        fields = to_fields([line], 'TABLED1')
+        self.assertEqual(fields[0], 'TABLED1')
+        self.assertEqual(fields[1], '100')
+
+    def test_csv_trailing_comma_marker_ok(self):
+        """A trailing comma after the field-10 marker is not counted as a field."""
+        line = 'CORD2R,5,,0.,0.,0.,0.,0.,1.0,+C1,'
+        fields = to_fields([line], 'CORD2R')
+        self.assertEqual(len(fields), 9)
+        self.assertEqual(fields[8], '1.0')
+
+    def test_csv_continuation_overflow_raises(self):
+        """A continuation line with 10 data tokens raises CardParseSyntaxError."""
+        line1 = 'PBAR,1,1,1.0,2.0,3.0,4.0,5.0,6.0'
+        line2 = ',8.0,9.0,10.0,11.0,12.0,13.0,14.0,15.0,16.0,17.0'
+        with self.assertRaises(CardParseSyntaxError):
+            to_fields([line1, line2], 'PBAR')
+
+    def test_csv_continuation_9_data_raises(self):
+        """9 data fields on a continuation line is overflow (field 10 = data)."""
+        line1 = 'GRID,1,,1.0,2.0,3.0,,,1'
+        line2 = ',100,101,102,103,104,105,106,107,108'
+        with self.assertRaises(CardParseSyntaxError):
+            to_fields([line1, line2], 'GRID')
+
+    def test_csv_line0_marker_stripped(self):
+        """A marker in the last data slot of a CSV line-0 is stripped."""
+        line = 'GRID,1,,1.0,2.0,3.0,,,+'
+        fields = to_fields([line], 'GRID')
+        self.assertEqual(len(fields), 9)
+        self.assertNotIn('+', fields)
+
+    def test_csv_continuation_marker_stripped(self):
+        """A marker in the last data slot of a CSV continuation is stripped."""
+        line1 = 'GRID,1,,1.0,2.0,3.0,,,1'
+        line2 = ',100,101,102,103,104,105,106,+B'
+        fields = to_fields([line1, line2], 'GRID')
+        self.assertEqual(len(fields), 9 + 8)
+        self.assertNotIn('+B', fields)
+
+
+class TestReadBdfFreeFieldOverflow(unittest.TestCase):
+    """read_bdf rejects free-field lines that exceed the 10-field line grammar."""
+
+    def test_read_bdf_grid_line0_overflow_raises(self):
+        """An 11-token GRID line raises instead of silently dropping the overflow."""
+        bdf = 'SOL 101\nCEND\nBEGIN BULK\nGRID,1,,1.0,2.0,3.0,,,1,999,888\nENDDATA\n'
+        with self.assertRaises(CardParseSyntaxError):
+            read_bdf(StringIO(bdf), validate=False, xref=False)
+
+    def test_read_bdf_pbar_continuation_overflow_raises(self):
+        """A PBAR continuation with 10 data tokens raises instead of using defaults."""
+        bdf = (
+            'SOL 101\nCEND\nBEGIN BULK\n'
+            'PBAR,1,1,1.0,2.0,3.0,4.0,5.0,6.0,7.0\n'
+            ',8.0,9.0,10.0,11.0,12.0,13.0,14.0,15.0,16.0,17.0\n'
+            'ENDDATA\n')
+        with self.assertRaises(CardParseSyntaxError):
+            read_bdf(StringIO(bdf), validate=False, xref=False)
+
+    def test_read_bdf_cord2c_one_line_rejected(self):
+        """A one-line 12-token CORD2C is malformed and raises."""
+        bdf = (
+            'SOL 101\nCEND\nBEGIN BULK\n'
+            'CORD2C,1,0,0.,0.,0.,0.,0.,1.,0.,1.,0.\n'
+            'ENDDATA\n')
+        with self.assertRaises(CardParseSyntaxError):
+            read_bdf(StringIO(bdf), validate=False, xref=False)
+
+    def test_read_bdf_cord2c_two_line_ok(self):
+        """The same CORD2C in two lines parses and gives the written frame."""
+        bdf = (
+            'SOL 101\nCEND\nBEGIN BULK\n'
+            'CORD2C,1,0,0.,0.,0.,0.,0.,1.\n'
+            ',0.,1.,0.\n'
+            'ENDDATA\n')
+        model = read_bdf(StringIO(bdf), validate=False, xref=False)
+        coord = model.coords[1]
+        self.assertEqual(coord.e2.tolist(), [0., 0., 1.])
+        self.assertEqual(coord.e3.tolist(), [0., 1., 0.])
+
+    def test_read_bdf_dmi_row_overflow_ok(self):
+        """DMI matrix data rows may exceed 10 fields (variable-length rows)."""
+        bdf = (
+            'DMI,ZRO,0,2,1,0,,11,1\n'
+            'DMI,ZRO,1,1,1.0,1.0,1.0,1.0,1.0,2.0,3.0\n')
+        model = read_bdf(StringIO(bdf), validate=False, xref=False, punch=True)
+        self.assertIn('ZRO', model.dmi)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/pyNastran/bdf/bdf_interface/utils.py
+++ b/pyNastran/bdf/bdf_interface/utils.py
@@ -31,6 +31,8 @@ _REMOVED_LINES = [
     '$SETS', '$CONTACT', '$REJECTS', '$REJECT_LINES',
     '$PROPERTIES_MASS', '$MASSES',
 ]
+# matrix data cards have variable-length rows; the 10-field line rule does not apply
+_DIRECT_MATRIX_CARDS = {'DMI', 'DMIG', 'DMIAX', 'DMIJ', 'DMIJI', 'DMIK', 'DTI'}
 EXPECTED_HEADER_KEYS_CHECK = [
     'version', 'encoding', 'nnodes', 'nelements',
     'punch', 'dumplines', 'is_superelements',  # booleans
@@ -427,6 +429,30 @@ def _strip_continuation_marker(new_fields: list[str]) -> None:
     new_fields[-1] = ''
 
 
+def _validate_free_field_line(card_name: str, line: str) -> None:
+    """Raises CardParseSyntaxError if a free-field line exceeds the 10-field
+    line grammar (the 10th field is the continuation-marker slot)."""
+    if card_name in _DIRECT_MATRIX_CARDS:
+        return
+    tokens = line.rstrip(',').split(',')
+    if len(tokens) > 10:
+        msg = (
+            f'card_name={card_name!r}\n'
+            f'{len(tokens)} free-field fields were found on one line; '
+            f'a free-field line has at most 10 fields, the 10th being the continuation marker\n'
+            f'line={line!r}')
+        raise CardParseSyntaxError(msg)
+    if len(tokens) == 10:
+        field10 = tokens[9].strip()
+        if field10 and field10[0] not in '+*':
+            msg = (
+                f'card_name={card_name!r}\n'
+                f'field 10 holds {field10!r}; field 10 is reserved for the '
+                f'continuation marker and cannot hold data\n'
+                f'line={line!r}')
+            raise CardParseSyntaxError(msg)
+
+
 def _to_fields_standard(card_lines: list[str], card_name: str) -> list[str]:
     fields: list[str] = []
     # first line
@@ -450,10 +476,12 @@ def _to_fields_standard(card_lines: list[str], card_name: str) -> list[str]:
         fields += new_fields
     else:  # small field
         if ',' in line:  # csv
+            _validate_free_field_line(card_name, line)
             new_fields = line.split(',')[:9]
             for unused_i in range(9 - len(new_fields)):
                 new_fields.append('')
             assert len(new_fields) == 9, new_fields
+            _strip_continuation_marker(new_fields)
         else:  # standard
             new_fields = [line[0:8], line[8:16], line[16:24], line[24:32],
                           line[32:40], line[40:48], line[48:56], line[56:64],
@@ -478,9 +506,11 @@ def _to_fields_standard(card_lines: list[str], card_name: str) -> list[str]:
                 new_fields = [line[8:24], line[24:40], line[40:56], line[56:72]]
         else:  # small field
             if ',' in line:  # csv
+                _validate_free_field_line(card_name, line)
                 new_fields = line.split(',')[1:9]
                 for unused_i in range(8 - len(new_fields)):
                     new_fields.append('')
+                _strip_continuation_marker(new_fields)
             else:  # standard
                 new_fields = [line[8:16], line[16:24], line[24:32],
                               line[32:40], line[40:48], line[48:56],


### PR DESCRIPTION
> **Correction (2026-08-03): the premise below is wrong — don't merge as-is.** The MSC QRG
> documents free-field lines with more than 10 fields as legal, with automatic continuation
> (`SPC1,100,12456,1,2,3,4,5,6,7,8,9,10` is a worked example in "Format of Bulk Data Entries").
> The 10-field limit applies to the logical entry, not to a free-field line, so rejecting long
> lines rejects valid input and the CORD2C model edit here is backwards. Details and a
> measured alternative in the thread below.

Free-field (CSV) lines with more fields than the 10-field line grammar were silently
truncated: `_to_fields_standard()` slices `split(',')` at `[:9]`/`[1:9]` and drops the
overflow with no diagnostic, so a malformed line parsed "successfully" with the extra
fields gone (an 11-token GRID loses fields 10-11; a PBAR continuation with 10 data tokens
falls back to the k1/k2 defaults). The MSC QRG says a free-field line has at most 10
fields and the 10th is the continuation slot.

The reader now raises `CardParseSyntaxError` when a free-field line exceeds that grammar,
and applies the continuation-marker strip to the CSV paths like the fixed-format path
already does. The corpus model `static_solid_shell_bar_global_radial_cd.bdf` had a
one-line 12-token CORD2C that was truncated and crashed with a degenerate frame; it is
split into the valid two-line form. DMI/DMIG/DMIJ/DMIJI/DMIK/DMIAX/DTI rows are exempt
(variable-length matrix rows can exceed 10 fields).

Local: `pytest pyNastran/bdf/bdf_interface/test/test_utils.py` 37 passed; full
bdf+interface+cards suite 902 passed (12 pre-existing env failures, unchanged). Corpus
census over 271 tracked .bdf files: no currently-parseable line is rejected. 14 new
tests cover the overflow errors, the field-10 marker boundary, and the matrix escape
hatch.
