### PR TITLE
Read free-field matrix and large-field CSV rows without truncation

### DIFF
--- a/models/sol_101_elements/static_solid_shell_bar_global_radial_cd.bdf
+++ b/models/sol_101_elements/static_solid_shell_bar_global_radial_cd.bdf
@@ -66,5 +66,6 @@ SPC1     123456     456  5       thru    13
 $ Nodal Forces of Load Set : 10000
 FORCE    10000   13      0      10000.   0.      0.     1.
 $ Referenced Coordinate Frames
-CORD2C,1,0, 0.,0.,0., 0.,0.,1., 0.,1.,0.
+CORD2C,1,0,0.,0.,0.,0.,0.,1.
+,0.,1.,0.
 ENDDATA 58e050da

--- a/pyNastran/bdf/bdf_interface/test/test_utils.py
+++ b/pyNastran/bdf/bdf_interface/test/test_utils.py
@@ -310,6 +310,30 @@ class TestToFields(unittest.TestCase):
         self.assertEqual(len(fields), 9 + 8)
         self.assertNotIn('+B', fields)
 
+    def test_matrix_card_free_field_row_not_truncated(self):
+        """DMI/DMIG-family rows are variable-length; the 9-field cap must not apply."""
+        fields = to_fields(['DMI,AAA,1,1,1.0,1.0,1.0,1.0,1.0,2.0,3.0'], 'DMI')
+        self.assertEqual(len(fields), 11)
+        self.assertEqual(fields[9], '2.0')
+        self.assertEqual(fields[10], '3.0')
+
+    def test_large_field_csv_line0_overflow(self):
+        """A 6-token large-field CSV line-0 exceeds the 5-field grammar."""
+        with self.assertRaises(CardParseSyntaxError):
+            to_fields(['PBAR*,1,1.0,2.0,3.0,4.0,5.0'], 'PBAR')
+
+    def test_large_field_csv_continuation_overflow(self):
+        """A large-field continuation holds 4 data fields; 5 must raise."""
+        with self.assertRaises(CardParseSyntaxError):
+            to_fields(['GRID*,1,,1.0,2.0', '*,3.0,4.0,5.0,6.0,7.0'], 'GRID')
+
+    def test_large_field_csv_valid(self):
+        """5-field line-0 and 4-field continuations still parse."""
+        fields = to_fields(['GRID*,1,,1.0,2.0'], 'GRID')
+        self.assertEqual(fields, ['GRID*', '1', '', '1.0', '2.0'])
+        fields2 = to_fields(['GRID*,1,,1.0,2.0', '*,3.0,4.0'], 'GRID')
+        self.assertEqual(fields2[:7], ['GRID*', '1', '', '1.0', '2.0', '3.0', '4.0'])
+
 
 class TestReadBdfFreeFieldOverflow(unittest.TestCase):
     """read_bdf rejects free-field lines that exceed the 10-field line grammar."""

--- a/pyNastran/bdf/bdf_interface/test/test_utils.py
+++ b/pyNastran/bdf/bdf_interface/test/test_utils.py
@@ -1,6 +1,8 @@
 """Tests for pyNastran.bdf.bdf_interface.utils (to_fields, expand_tabs)."""
 import unittest
+from io import StringIO
 from pyNastran.bdf.bdf_interface.utils import to_fields, expand_tabs
+from pyNastran.bdf.bdf import read_bdf
 from pyNastran.bdf.errors import CardParseSyntaxError
 
 
@@ -245,6 +247,117 @@ class TestToFields(unittest.TestCase):
         line2 = '*        100'
         fields = to_fields([line1, line2], 'CARD')
         self.assertEqual(fields[8].strip(), '')
+
+    def test_csv_line0_overflow_raises(self):
+        """A free-field line-0 with more than 10 fields raises CardParseSyntaxError."""
+        line = 'GRID,1,,1.0,2.0,3.0,,,1,999,888'
+        with self.assertRaises(CardParseSyntaxError):
+            to_fields([line], 'GRID')
+
+    def test_csv_field10_data_raises(self):
+        """Data in field 10 (the continuation slot) raises CardParseSyntaxError."""
+        line = 'GRID,1,,1.0,2.0,3.0,,,1,999'
+        with self.assertRaises(CardParseSyntaxError):
+            to_fields([line], 'GRID')
+
+    def test_csv_field10_marker_ok(self):
+        """A continuation marker in field 10 is dropped, not an error."""
+        line = 'GRID,1,,1.0,2.0,3.0,,,1,+'
+        fields = to_fields([line], 'GRID')
+        self.assertEqual(len(fields), 9)
+        self.assertNotIn('+', fields)
+
+    def test_csv_field10_numeric_marker_ok(self):
+        """A numeric continuation marker like '+01' is allowed in field 10."""
+        line = 'TABLED1,100,,,,,,,,+01'
+        fields = to_fields([line], 'TABLED1')
+        self.assertEqual(fields[0], 'TABLED1')
+        self.assertEqual(fields[1], '100')
+
+    def test_csv_trailing_comma_marker_ok(self):
+        """A trailing comma after the field-10 marker is not counted as a field."""
+        line = 'CORD2R,5,,0.,0.,0.,0.,0.,1.0,+C1,'
+        fields = to_fields([line], 'CORD2R')
+        self.assertEqual(len(fields), 9)
+        self.assertEqual(fields[8], '1.0')
+
+    def test_csv_continuation_overflow_raises(self):
+        """A continuation line with 10 data tokens raises CardParseSyntaxError."""
+        line1 = 'PBAR,1,1,1.0,2.0,3.0,4.0,5.0,6.0'
+        line2 = ',8.0,9.0,10.0,11.0,12.0,13.0,14.0,15.0,16.0,17.0'
+        with self.assertRaises(CardParseSyntaxError):
+            to_fields([line1, line2], 'PBAR')
+
+    def test_csv_continuation_9_data_raises(self):
+        """9 data fields on a continuation line is overflow (field 10 = data)."""
+        line1 = 'GRID,1,,1.0,2.0,3.0,,,1'
+        line2 = ',100,101,102,103,104,105,106,107,108'
+        with self.assertRaises(CardParseSyntaxError):
+            to_fields([line1, line2], 'GRID')
+
+    def test_csv_line0_marker_stripped(self):
+        """A marker in the last data slot of a CSV line-0 is stripped."""
+        line = 'GRID,1,,1.0,2.0,3.0,,,+'
+        fields = to_fields([line], 'GRID')
+        self.assertEqual(len(fields), 9)
+        self.assertNotIn('+', fields)
+
+    def test_csv_continuation_marker_stripped(self):
+        """A marker in the last data slot of a CSV continuation is stripped."""
+        line1 = 'GRID,1,,1.0,2.0,3.0,,,1'
+        line2 = ',100,101,102,103,104,105,106,+B'
+        fields = to_fields([line1, line2], 'GRID')
+        self.assertEqual(len(fields), 9 + 8)
+        self.assertNotIn('+B', fields)
+
+
+class TestReadBdfFreeFieldOverflow(unittest.TestCase):
+    """read_bdf rejects free-field lines that exceed the 10-field line grammar."""
+
+    def test_read_bdf_grid_line0_overflow_raises(self):
+        """An 11-token GRID line raises instead of silently dropping the overflow."""
+        bdf = 'SOL 101\nCEND\nBEGIN BULK\nGRID,1,,1.0,2.0,3.0,,,1,999,888\nENDDATA\n'
+        with self.assertRaises(CardParseSyntaxError):
+            read_bdf(StringIO(bdf), validate=False, xref=False)
+
+    def test_read_bdf_pbar_continuation_overflow_raises(self):
+        """A PBAR continuation with 10 data tokens raises instead of using defaults."""
+        bdf = (
+            'SOL 101\nCEND\nBEGIN BULK\n'
+            'PBAR,1,1,1.0,2.0,3.0,4.0,5.0,6.0,7.0\n'
+            ',8.0,9.0,10.0,11.0,12.0,13.0,14.0,15.0,16.0,17.0\n'
+            'ENDDATA\n')
+        with self.assertRaises(CardParseSyntaxError):
+            read_bdf(StringIO(bdf), validate=False, xref=False)
+
+    def test_read_bdf_cord2c_one_line_rejected(self):
+        """A one-line 12-token CORD2C is malformed and raises."""
+        bdf = (
+            'SOL 101\nCEND\nBEGIN BULK\n'
+            'CORD2C,1,0,0.,0.,0.,0.,0.,1.,0.,1.,0.\n'
+            'ENDDATA\n')
+        with self.assertRaises(CardParseSyntaxError):
+            read_bdf(StringIO(bdf), validate=False, xref=False)
+
+    def test_read_bdf_cord2c_two_line_ok(self):
+        """The same CORD2C in two lines parses and gives the written frame."""
+        bdf = (
+            'SOL 101\nCEND\nBEGIN BULK\n'
+            'CORD2C,1,0,0.,0.,0.,0.,0.,1.\n'
+            ',0.,1.,0.\n'
+            'ENDDATA\n')
+        model = read_bdf(StringIO(bdf), validate=False, xref=False)
+        coord = model.coords[1]
+        self.assertEqual(coord.e2.tolist(), [0., 0., 1.])
+        self.assertEqual(coord.e3.tolist(), [0., 1., 0.])
+
+    def test_read_bdf_dmi_row_overflow_ok(self):
+        """DMI matrix data rows may exceed 10 fields (variable-length rows)."""
+        bdf = (
+            'DMI,ZRO,0,2,1,0,,11,1\n'
+            'DMI,ZRO,1,1,1.0,1.0,1.0,1.0,1.0,2.0,3.0\n')
+        model = read_bdf(StringIO(bdf), validate=False, xref=False, punch=True)
+        self.assertIn('ZRO', model.dmi)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/pyNastran/bdf/bdf_interface/utils.py
+++ b/pyNastran/bdf/bdf_interface/utils.py
@@ -31,6 +31,8 @@ _REMOVED_LINES = [
     '$SETS', '$CONTACT', '$REJECTS', '$REJECT_LINES',
     '$PROPERTIES_MASS', '$MASSES',
 ]
+# matrix data cards have variable-length rows; the 10-field line rule does not apply
+_DIRECT_MATRIX_CARDS = {'DMI', 'DMIG', 'DMIAX', 'DMIJ', 'DMIJI', 'DMIK', 'DTI'}
 EXPECTED_HEADER_KEYS_CHECK = [
     'version', 'encoding', 'nnodes', 'nelements',
     'punch', 'dumplines', 'is_superelements',  # booleans
@@ -427,6 +429,30 @@ def _strip_continuation_marker(new_fields: list[str]) -> None:
     new_fields[-1] = ''
 
 
+def _validate_free_field_line(card_name: str, line: str) -> None:
+    """Raises CardParseSyntaxError if a free-field line exceeds the 10-field
+    line grammar (the 10th field is the continuation-marker slot)."""
+    if card_name in _DIRECT_MATRIX_CARDS:
+        return
+    tokens = line.rstrip(',').split(',')
+    if len(tokens) > 10:
+        msg = (
+            f'card_name={card_name!r}\n'
+            f'{len(tokens)} free-field fields were found on one line; '
+            f'a free-field line has at most 10 fields, the 10th being the continuation marker\n'
+            f'line={line!r}')
+        raise CardParseSyntaxError(msg)
+    if len(tokens) == 10:
+        field10 = tokens[9].strip()
+        if field10 and field10[0] not in '+*':
+            msg = (
+                f'card_name={card_name!r}\n'
+                f'field 10 holds {field10!r}; field 10 is reserved for the '
+                f'continuation marker and cannot hold data\n'
+                f'line={line!r}')
+            raise CardParseSyntaxError(msg)
+
+
 def _to_fields_standard(card_lines: list[str], card_name: str) -> list[str]:
     fields: list[str] = []
     # first line
@@ -450,10 +476,12 @@ def _to_fields_standard(card_lines: list[str], card_name: str) -> list[str]:
         fields += new_fields
     else:  # small field
         if ',' in line:  # csv
+            _validate_free_field_line(card_name, line)
             new_fields = line.split(',')[:9]
             for unused_i in range(9 - len(new_fields)):
                 new_fields.append('')
             assert len(new_fields) == 9, new_fields
+            _strip_continuation_marker(new_fields)
         else:  # standard
             new_fields = [line[0:8], line[8:16], line[16:24], line[24:32],
                           line[32:40], line[40:48], line[48:56], line[56:64],
@@ -478,9 +506,11 @@ def _to_fields_standard(card_lines: list[str], card_name: str) -> list[str]:
                 new_fields = [line[8:24], line[24:40], line[40:56], line[56:72]]
         else:  # small field
             if ',' in line:  # csv
+                _validate_free_field_line(card_name, line)
                 new_fields = line.split(',')[1:9]
                 for unused_i in range(8 - len(new_fields)):
                     new_fields.append('')
+                _strip_continuation_marker(new_fields)
             else:  # standard
                 new_fields = [line[8:16], line[16:24], line[24:32],
                               line[32:40], line[40:48], line[48:56],

--- a/pyNastran/bdf/bdf_interface/utils.py
+++ b/pyNastran/bdf/bdf_interface/utils.py
@@ -453,6 +453,18 @@ def _validate_free_field_line(card_name: str, line: str) -> None:
             raise CardParseSyntaxError(msg)
 
 
+def _validate_large_field_csv_line(line: str) -> None:
+    """Raises CardParseSyntaxError if a large-field CSV line exceeds the
+    5-field line grammar (line-0 has 5 fields; a continuation has 4)."""
+    tokens = line.rstrip(',').split(',')
+    if len(tokens) > 5:
+        msg = (
+            f'{len(tokens)} free-field fields were found on one line; '
+            f'a large-field free-field line has at most 5 fields\n'
+            f'line={line!r}')
+        raise CardParseSyntaxError(msg)
+
+
 def _to_fields_standard(card_lines: list[str], card_name: str) -> list[str]:
     fields: list[str] = []
     # first line
@@ -466,6 +478,7 @@ def _to_fields_standard(card_lines: list[str], card_name: str) -> list[str]:
 
     if '*' in line:  # large field
         if ',' in line:  # csv
+            _validate_large_field_csv_line(line)
             new_fields = line.split(',')[:5]
             for unused_i in range(5 - len(new_fields)):
                 new_fields.append('')
@@ -477,11 +490,18 @@ def _to_fields_standard(card_lines: list[str], card_name: str) -> list[str]:
     else:  # small field
         if ',' in line:  # csv
             _validate_free_field_line(card_name, line)
-            new_fields = line.split(',')[:9]
-            for unused_i in range(9 - len(new_fields)):
-                new_fields.append('')
-            assert len(new_fields) == 9, new_fields
-            _strip_continuation_marker(new_fields)
+            if card_name in _DIRECT_MATRIX_CARDS:
+                # variable-length matrix rows; drop a trailing continuation marker
+                new_fields = line.split(',')
+                _strip_continuation_marker(new_fields)
+                if new_fields and new_fields[-1] == '':
+                    new_fields.pop()
+            else:
+                new_fields = line.split(',')[:9]
+                for unused_i in range(9 - len(new_fields)):
+                    new_fields.append('')
+                assert len(new_fields) == 9, new_fields
+                _strip_continuation_marker(new_fields)
         else:  # standard
             new_fields = [line[0:8], line[8:16], line[16:24], line[24:32],
                           line[32:40], line[40:48], line[48:56], line[56:64],
@@ -498,6 +518,7 @@ def _to_fields_standard(card_lines: list[str], card_name: str) -> list[str]:
 
         if '*' in line:  # large field
             if ',' in line:  # csv
+                _validate_large_field_csv_line(line)
                 new_fields = line.split(',')[1:5]
                 for unused_i in range(4 - len(new_fields)):
                     new_fields.append('')
@@ -507,16 +528,23 @@ def _to_fields_standard(card_lines: list[str], card_name: str) -> list[str]:
         else:  # small field
             if ',' in line:  # csv
                 _validate_free_field_line(card_name, line)
-                new_fields = line.split(',')[1:9]
-                for unused_i in range(8 - len(new_fields)):
-                    new_fields.append('')
-                _strip_continuation_marker(new_fields)
+                if card_name in _DIRECT_MATRIX_CARDS:
+                    # variable-length matrix rows; drop a trailing continuation marker
+                    new_fields = line.split(',')[1:]
+                    _strip_continuation_marker(new_fields)
+                    if new_fields and new_fields[-1] == '':
+                        new_fields.pop()
+                else:
+                    new_fields = line.split(',')[1:9]
+                    for unused_i in range(8 - len(new_fields)):
+                        new_fields.append('')
+                    _strip_continuation_marker(new_fields)
             else:  # standard
                 new_fields = [line[8:16], line[16:24], line[24:32],
                               line[32:40], line[40:48], line[48:56],
                               line[56:64], line[64:72]]
                 _strip_continuation_marker(new_fields)
-            if len(new_fields) != 8:
+            if card_name not in _DIRECT_MATRIX_CARDS and len(new_fields) != 8:
                 nfields = len(new_fields)
                 msg = 'nfields=%s new_fields=%s' % (nfields, new_fields)
                 raise RuntimeError(msg)

--- a/pyNastran/bdf/cards/test/test_dmig.py
+++ b/pyNastran/bdf/cards/test/test_dmig.py
@@ -430,6 +430,76 @@ DMI         W2GJ       1       1 1.54685.1353939.1312423.0986108.0621382
         finally:
             os.remove(fname)
 
+    def test_dmi_long_free_field_row_keeps_all_values(self):
+        """An 11-token free-field DMI row must keep rows 6-7.
+
+        The [:9] slice previously dropped the overflow tokens silently;
+        test_dmi_real_with_zeros only passed because its overflow values
+        were zeros.
+        """
+        from io import StringIO
+
+        bdf_str = (
+            "CEND\nBEGIN BULK\n"
+            "DMI,AAA,0,2,1,0,,7,1\n"
+            "DMI,AAA,1,1,1.0,1.0,1.0,1.0,1.0,2.0,3.0\n"
+            "ENDDATA\n"
+        )
+        model = BDF(debug=False)
+        model.read_bdf(StringIO(bdf_str), punch=False)
+        mat = model.dmi["AAA"].get_matrix(is_sparse=False)[0]
+        assert mat.shape == (7, 1), mat.shape
+        expected = np.array([1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 3.0])
+        assert np.array_equal(mat.flatten(), expected), (
+            f"mat={mat.flatten()}\nexpected={expected}"
+        )
+
+    def test_dmig_long_free_field_row_keeps_all_entries(self):
+        """A 12-token free-field DMIG row must keep both (Gi, Ci, value) triples.
+
+        The [:9] slice previously cut DMIG rows to 9 fields, silently dropping
+        every entry after the first.
+        """
+        from io import StringIO
+
+        bdf_str = (
+            "CEND\nBEGIN BULK\n"
+            "DMIG,CC,0,2,1,0,,5,1\n"
+            "DMIG,CC,1,1,,2,3,4.0,,5,6,7.0\n"
+            "ENDDATA\n"
+        )
+        model = BDF(debug=False)
+        model.read_bdf(StringIO(bdf_str), punch=False)
+        assert 'CC' in model.dmig
+        mat = model.dmig['CC'].get_matrix(is_sparse=False)[0]
+        assert mat.shape == (2, 1), mat.shape
+        assert np.array_equal(mat.flatten(), [4.0, 7.0]), (
+            f"mat={mat.flatten()}\nexpected=[4.0, 7.0]"
+        )
+
+    def test_dmi_long_free_field_continuation_keeps_all_values(self):
+        """A long leading-comma continuation must also be read in full.
+
+        Rows 6-10 are written on the continuation line; the [1:9] slice on
+        continuation lines previously dropped the trailing pairs.
+        """
+        from io import StringIO
+
+        bdf_str = (
+            "CEND\nBEGIN BULK\n"
+            "DMI,AAA,0,2,1,0,,11,1\n"
+            "DMI,AAA,1,1,1.0,1.0\n"
+            ",6,2.0,7,3.0,8,4.0,9,5.0,10,6.0\n"
+            "ENDDATA\n"
+        )
+        model = BDF(debug=False)
+        model.read_bdf(StringIO(bdf_str), punch=False)
+        mat = model.dmi["AAA"].get_matrix(is_sparse=False)[0]
+        expected = np.array([1.0, 1.0, 0.0, 0.0, 0.0, 2.0, 3.0, 4.0, 5.0, 6.0, 0.0])
+        assert np.array_equal(mat.flatten(), expected), (
+            f"mat={mat.flatten()}\nexpected={expected}"
+        )
+
     def test_dmi_real_int_zero_raises(self):
         """Tests that "0" (parsed as int) in a DMI value field raises AssertionError.
 


### PR DESCRIPTION
_to_fields_standard still silently truncated free-field lines on the two paths #869 did not cover: the variable-length matrix-card exemption and the large-field CSV path.

- **Matrix cards (H1)** — DMI/DMIG/DMIAX/DMIJ/DMIJI/DMIK/DTI have variable-length data rows; #869 exempted them from the 10-field validation but left the `[:9]`/`[1:9]` slices live. An 11-token DMI row therefore lost rows 6-7 with no error (`test_dmi_real_with_zeros` masks this because its overflow values are zeros), and a 12-token DMIG row lost every (Gi, Ci, value) after the first.
- **Large-field CSV (H2)** — no validation at all: a 6-token `PBAR*,...` line-0 or a 5-data-field `*,...` continuation was silently cut at 5/4 fields.

The fix reads matrix-card rows in full (the matrix readers already consume variable-length rows) and validates large-field CSV lines with a 5-field cap, symmetric with the #869 validation.

repro (H1):
```
DMI,AAA,0,2,1,0,,7,1
DMI,AAA,1,1,1.0,1.0,1.0,1.0,1.0,2.0,3.0
```
`read_bdf` returned rows 1-7 = [1,1,1,1,1,0,0] on main (2.0/3.0 silently dropped); now [1,1,1,1,1,2,3].

Tests: DMI/DMIG full-row and leading-comma continuation cases, large-field overflow plus valid controls — `pytest pyNastran/bdf/bdf_interface/test/test_utils.py pyNastran/bdf/cards/test/test_dmig.py` -> 85 passed.