### PR TITLE
Cap requires-python at <3.13 on the 1.4 line

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,12 @@ readme = {file="README.md", content-type="text/markdown"}
 #readme = {file="README.rst", content-type="text/x-rst"}
 #readme = "README.rst"
 
-requires-python = '>=3.9'
+# The numpy<2 pin below resolves to numpy 1.26.4, which ships no cp313
+# wheel and does not support Python 3.13+. Without an upper bound here a
+# resolver builds numpy from source on 3.13/3.14 and produces an unusable
+# one, so this cap is what makes the failure honest. Lifted on main/1.5,
+# which allow numpy 2.
+requires-python = '>=3.9,<3.13'
 
 #keywords = ["packaging", "dependency", "infer", "pyproject.toml"]
 keywords = ["nastran"]


### PR DESCRIPTION
A follow-up to #846, and entirely optional — it only matters if a 1.4.2 is worth cutting before 1.5.

1.4.1 declares `numpy<2` with `requires-python = '>=3.9'` and no upper bound. The only numpy satisfying `<2` is 1.26.4, which ships no cp313 wheel and supports 3.9–3.12 only — and which itself declares `Requires-Python: >=3.9` with no upper bound of its own. So on 3.13+ a resolver sees a valid solution, finds no wheel, and builds numpy from source.

On our CI (`windows-latest`, Python 3.13.9) that build **succeeds**, takes about seven minutes, and then importing the result dies with:

```
Windows fatal exception: access violation

Current thread 0x00002290 (most recent call first):
  File ".../numpy/core/getlimits.py", line 52 in __init__
  File ".../numpy/core/getlimits.py", line 230 in _register_known_types
  File ".../numpy/__init__.py", line 235 in <module>
  ...
  File ".../pyNastran/op2/op2.py", line 30 in <module>
```

`op2.py:30` is `import numpy as np` — pyNastran is just the first importer and, having no compiled extensions, cannot fault itself. Whether it faults at all depends on process memory layout, so the same install can crash, raise a clean `ImportError`, or appear to work. That is why this has been awkward to reproduce.

With the cap, pip and uv say immediately:

```
requires a different Python: 3.13 not in '>=3.9,<3.13'
```

Nothing changes for 3.9–3.12, and nothing changes about what the code can do — 1.4.1 never worked on 3.13. This documents that rather than altering it.

Two notes:

- PyPI metadata cannot be edited after upload, so this only helps once it ships in a release. Being two lines and no code, it is also a low-risk way to confirm the publish path works before 1.5 goes out (see #873).
- Yanking 1.4.1 is deliberately **not** proposed: a yank still installs for anyone pinning it exactly, and would break working 3.9–3.12 installations for no gain.

Close this if 1.5 is close enough that a 1.4.2 is not worth the effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
